### PR TITLE
fix: add peer dependency on frontend-auth and upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1686,44 +1686,6 @@
         "find-up": "^2.1.0"
       }
     },
-    "@edx/frontend-auth": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-9.0.1.tgz",
-      "integrity": "sha512-1LzvioY1Lg52IzqNpoE/HqW2JwJR4OVO3tkQRLEDhgkzskd+qJTSfj4WL0Zmicho8OLckHKlU5bqUd9r1Vi3hA==",
-      "dev": true,
-      "requires": {
-        "axios": "^0.18.1",
-        "camelcase-keys": "^5.0.0",
-        "jwt-decode": "^2.2.0",
-        "snakecase-keys": "^2.1.0",
-        "universal-cookie": "^3.0.4"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "camelcase-keys": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-5.2.0.tgz",
-          "integrity": "sha512-mSM/OQKD1HS5Ll2AXxeaHSdqCGC/QQ8IrgTbKYA/rxnC36thBKysfIr9+OVBWuW17jyZF4swHkjtglawgBmVFg==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.3.1",
-            "map-obj": "^3.0.0",
-            "quick-lru": "^1.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-3.1.0.tgz",
-          "integrity": "sha512-Xg1iyYz/+iIW6YoMldux47H/e5QZyDSB41Kb0ev+YYHh3FJnyyzY0vTk/WbVeWcCvdXd70cOriUBmhP8alUFBA==",
-          "dev": true
-        }
-      }
-    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
@@ -2330,12 +2292,6 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@types/cookie": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
-      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
-      "dev": true
-    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2369,12 +2325,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
-      "dev": true
-    },
-    "@types/object-assign": {
-      "version": "4.0.30",
-      "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
-      "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI=",
       "dev": true
     },
     "@types/retry": {
@@ -2985,24 +2935,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        }
-      }
     },
     "axios-mock-adapter": {
       "version": "1.17.0",
@@ -4945,12 +4877,6 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
-    },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -7373,26 +7299,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dev": true,
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "for-in": {
@@ -9903,12 +9809,6 @@
         "array-includes": "^3.0.3",
         "object.assign": "^4.1.0"
       }
-    },
-    "jwt-decode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
-      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=",
-      "dev": true
     },
     "keyv": {
       "version": "3.1.0",
@@ -16994,24 +16894,6 @@
         }
       }
     },
-    "snakecase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-2.1.0.tgz",
-      "integrity": "sha512-oQSiCIgNCwixBf8Kxgv0SPo67zQSutIEymAk/dkgcdZEOMPvGMGPua/WwYGPG4LLHArGGews3CB3zEEfqlMk2g==",
-      "dev": true,
-      "requires": {
-        "map-obj": "~3.0.0",
-        "to-snake-case": "~1.0.0"
-      },
-      "dependencies": {
-        "map-obj": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-3.0.0.tgz",
-          "integrity": "sha512-Ot+2wruG8WqTbJngDxz0Ifm03y2pO4iL+brq/l+yEkGjUza03BnMQqX2XT//Jls8MOOl2VTHviAoLX+/nq/HXw==",
-          "dev": true
-        }
-      }
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -18097,12 +17979,6 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "to-no-case": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
-      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo=",
-      "dev": true
-    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -18149,24 +18025,6 @@
             "kind-of": "^3.0.2"
           }
         }
-      }
-    },
-    "to-snake-case": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
-      "integrity": "sha1-znRpE4l5RgGah+Yu366upMYIq4w=",
-      "dev": true,
-      "requires": {
-        "to-space-case": "^1.0.0"
-      }
-    },
-    "to-space-case": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
-      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
-      "dev": true,
-      "requires": {
-        "to-no-case": "^1.0.0"
       }
     },
     "tough-cookie": {
@@ -18620,18 +18478,6 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
-      }
-    },
-    "universal-cookie": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-3.1.0.tgz",
-      "integrity": "sha512-sP6WuFgqIUro7ikgI2ndrsw9Ro+YvVBe5O9cQfWnjTicpLaSMUEUUDjQF8m8utzWF2ONl7tRkcZd7v4n6NnzjQ==",
-      "dev": true,
-      "requires": {
-        "@types/cookie": "^0.3.1",
-        "@types/object-assign": "^4.0.30",
-        "cookie": "^0.3.1",
-        "object-assign": "^4.1.0"
       }
     },
     "universal-user-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1686,6 +1686,44 @@
         "find-up": "^2.1.0"
       }
     },
+    "@edx/frontend-auth": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-9.0.1.tgz",
+      "integrity": "sha512-1LzvioY1Lg52IzqNpoE/HqW2JwJR4OVO3tkQRLEDhgkzskd+qJTSfj4WL0Zmicho8OLckHKlU5bqUd9r1Vi3hA==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.18.1",
+        "camelcase-keys": "^5.0.0",
+        "jwt-decode": "^2.2.0",
+        "snakecase-keys": "^2.1.0",
+        "universal-cookie": "^3.0.4"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-5.2.0.tgz",
+          "integrity": "sha512-mSM/OQKD1HS5Ll2AXxeaHSdqCGC/QQ8IrgTbKYA/rxnC36thBKysfIr9+OVBWuW17jyZF4swHkjtglawgBmVFg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.3.1",
+            "map-obj": "^3.0.0",
+            "quick-lru": "^1.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-3.1.0.tgz",
+          "integrity": "sha512-Xg1iyYz/+iIW6YoMldux47H/e5QZyDSB41Kb0ev+YYHh3FJnyyzY0vTk/WbVeWcCvdXd70cOriUBmhP8alUFBA==",
+          "dev": true
+        }
+      }
+    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
@@ -2292,6 +2330,12 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/cookie": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.3.3.tgz",
+      "integrity": "sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -2325,6 +2369,12 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
+    "@types/object-assign": {
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
+      "integrity": "sha1-iUk3HVqZ9Dge4PHfCpt6GH4H5lI=",
       "dev": true
     },
     "@types/retry": {
@@ -2935,6 +2985,24 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
+      }
     },
     "axios-mock-adapter": {
       "version": "1.17.0",
@@ -4877,6 +4945,12 @@
       "requires": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -7299,6 +7373,26 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "dev": true,
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-in": {
@@ -9809,6 +9903,12 @@
         "array-includes": "^3.0.3",
         "object.assign": "^4.1.0"
       }
+    },
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=",
+      "dev": true
     },
     "keyv": {
       "version": "3.1.0",
@@ -16894,6 +16994,24 @@
         }
       }
     },
+    "snakecase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-2.1.0.tgz",
+      "integrity": "sha512-oQSiCIgNCwixBf8Kxgv0SPo67zQSutIEymAk/dkgcdZEOMPvGMGPua/WwYGPG4LLHArGGews3CB3zEEfqlMk2g==",
+      "dev": true,
+      "requires": {
+        "map-obj": "~3.0.0",
+        "to-snake-case": "~1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-3.0.0.tgz",
+          "integrity": "sha512-Ot+2wruG8WqTbJngDxz0Ifm03y2pO4iL+brq/l+yEkGjUza03BnMQqX2XT//Jls8MOOl2VTHviAoLX+/nq/HXw==",
+          "dev": true
+        }
+      }
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -17979,6 +18097,12 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
+    "to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo=",
+      "dev": true
+    },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -18025,6 +18149,24 @@
             "kind-of": "^3.0.2"
           }
         }
+      }
+    },
+    "to-snake-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "integrity": "sha1-znRpE4l5RgGah+Yu366upMYIq4w=",
+      "dev": true,
+      "requires": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+      "dev": true,
+      "requires": {
+        "to-no-case": "^1.0.0"
       }
     },
     "tough-cookie": {
@@ -18478,6 +18620,18 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "universal-cookie": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/universal-cookie/-/universal-cookie-3.1.0.tgz",
+      "integrity": "sha512-sP6WuFgqIUro7ikgI2ndrsw9Ro+YvVBe5O9cQfWnjTicpLaSMUEUUDjQF8m8utzWF2ONl7tRkcZd7v4n6NnzjQ==",
+      "dev": true,
+      "requires": {
+        "@types/cookie": "^0.3.1",
+        "@types/object-assign": "^4.0.30",
+        "cookie": "^0.3.1",
+        "object-assign": "^4.1.0"
       }
     },
     "universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@commitlint/config-angular": "^6.0.2",
     "@commitlint/prompt": "^6.0.2",
     "@commitlint/prompt-cli": "^6.0.2",
-    "@edx/frontend-auth": "^9.0.1",
     "axios-mock-adapter": "^1.15.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "webpack-cli": "^3.1.0"
   },
   "peerDependencies": {
-    "@edx/frontend-auth": "^9.0.1"
+    "@edx/frontend-auth": "^9.0.0"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@commitlint/config-angular": "^6.0.2",
     "@commitlint/prompt": "^6.0.2",
     "@commitlint/prompt-cli": "^6.0.2",
+    "@edx/frontend-auth": "^9.0.1",
     "axios-mock-adapter": "^1.15.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
@@ -56,6 +57,9 @@
     "uglifyjs-webpack-plugin": "^1.1.8",
     "webpack": "^4.16.2",
     "webpack-cli": "^3.1.0"
+  },
+  "peerDependencies": {
+    "@edx/frontend-auth": "^9.0.1"
   },
   "jest": {
     "collectCoverageFrom": [

--- a/src/learnerPortalLinks.js
+++ b/src/learnerPortalLinks.js
@@ -1,3 +1,4 @@
+import { getAuthenticatedUser } from '@edx/frontend-auth';
 import { fetchEnterpriseCustomers } from './service';
 import { isEnterpriseLearner } from './utils';
 
@@ -60,14 +61,10 @@ function getCachedLearnerPortalLinks(userId) {
 
 export default async function getLearnerPortalLinks(apiClient) {
   let learnerPortalLinks = [];
-  let accessToken = apiClient.getDecodedAccessToken();
-  if (!accessToken) {
-    await apiClient.refreshAccessToken();
-    accessToken = apiClient.getDecodedAccessToken();
-  }
+  const authenticatedUser = await getAuthenticatedUser();
 
-  if (isEnterpriseLearner(accessToken)) {
-    const userId = accessToken.user_id;
+  if (authenticatedUser !== null && isEnterpriseLearner(authenticatedUser)) {
+    const { userId } = authenticatedUser;
     const cachedLinks = getCachedLearnerPortalLinks(userId);
 
     if (cachedLinks != null) {

--- a/src/learnerPortalLinks.js
+++ b/src/learnerPortalLinks.js
@@ -1,4 +1,4 @@
-import { getAuthenticatedUser } from '@edx/frontend-auth';
+import { getAuthenticatedUser } from '@edx/frontend-auth'; // eslint-disable-line
 import { fetchEnterpriseCustomers } from './service';
 import { isEnterpriseLearner } from './utils';
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
-function isEnterpriseLearner(accessToken) {
-  if (accessToken && accessToken.roles) {
-    const { roles } = accessToken;
+// eslint-disable-next-line import/prefer-default-export
+export function isEnterpriseLearner(user) {
+  if (user !== null && user.roles) {
+    const { roles } = user;
     for (let i = 0; i < roles.length; i += 1) {
       if (roles[i].includes('enterprise_learner')) {
         return true;
@@ -10,6 +11,3 @@ function isEnterpriseLearner(accessToken) {
 
   return false;
 }
-
-// eslint-disable-next-line import/prefer-default-export
-export { isEnterpriseLearner };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,12 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx'],
   },
+  externals: {
+    '@edx/frontend-auth': {
+      commonjs: '@edx/frontend-auth',
+      commonjs2: '@edx/frontend-auth',
+    },
+  },
   plugins: [
     new UglifyJsPlugin({
       sourceMap: true,


### PR DESCRIPTION
BREAKING CHANGE: This version requires @edx/frontend-auth v9.0.1 or later.  It is incompatible with prior versions of frontend-auth and will not function.  Because it’s a peer dependency, consumers of this library must provide a compatible version of @edx/frontend-auth.