### PR TITLE
feat: require passing user to learnerPortalLinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,9 +57,6 @@
     "webpack": "^4.16.2",
     "webpack-cli": "^3.1.0"
   },
-  "peerDependencies": {
-    "@edx/frontend-auth": "^9.0.0"
-  },
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise",
-  "version": "1.0.0-semantically-released",
+  "version": "2.0.0-semantically-released",
   "description": "Frontend utilities for supporting enterprise features.",
   "main": "dist/main.js",
   "publishConfig": {

--- a/src/learnerPortalLinks.js
+++ b/src/learnerPortalLinks.js
@@ -1,4 +1,3 @@
-import { getAuthenticatedUser } from '@edx/frontend-auth'; // eslint-disable-line
 import { fetchEnterpriseCustomers } from './service';
 import { isEnterpriseLearner } from './utils';
 
@@ -63,9 +62,8 @@ function getCachedLearnerPortalLinks(userId) {
   return null;
 }
 
-export default async function getLearnerPortalLinks(apiClient) {
+export default async function getLearnerPortalLinks(apiClient, authenticatedUser) {
   let learnerPortalLinks = [];
-  const authenticatedUser = await getAuthenticatedUser();
 
   if (authenticatedUser !== null && isEnterpriseLearner(authenticatedUser)) {
     const { userId } = authenticatedUser;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,18 +9,11 @@ module.exports = {
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    library: 'frontend-auth',
     libraryTarget: 'umd',
     globalObject: 'typeof self !== \'undefined\' ? self : this',
   },
   resolve: {
     extensions: ['.js', '.jsx'],
-  },
-  externals: {
-    '@edx/frontend-auth': {
-      commonjs: '@edx/frontend-auth',
-      commonjs2: '@edx/frontend-auth',
-    },
   },
   plugins: [
     new UglifyJsPlugin({


### PR DESCRIPTION
BREAKING CHANGE: getLearnerPortalLinks now requires a user to be passed
in. This is done to remove the dependency on frontend-auth so it can be
used in both edx-platform and other MFEs.

ENT-2648