### PR TITLE
fix: update version number in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise",
-  "version": "2.0.0-semantically-released",
+  "version": "1.0.0-semantically-released",
   "description": "Frontend utilities for supporting enterprise features.",
   "main": "dist/main.js",
   "publishConfig": {


### PR DESCRIPTION
There was no need to put 2.0.0 in the package json version. Apparently we just leave it at 1.0.0