### PR TITLE
feat: adds function to return the preferred enterprise uuid for a user

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,11 @@
+const ENTERPRISE_ADMIN = 'enterprise_admin';
+const ENTERPRISE_CATALOG_ADMIN = 'enterprise_catalog_admin';
+const ENTERPRISE_LEARNER = 'enterprise_learner';
+const ENTERPRISE_OPENEDX_OPERATOR = 'enterprise_openedx_operator';
+
+export {
+  ENTERPRISE_ADMIN,
+  ENTERPRISE_CATALOG_ADMIN,
+  ENTERPRISE_LEARNER,
+  ENTERPRISE_OPENEDX_OPERATOR,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/prefer-default-export
 export { default as getLearnerPortalLinks } from './learnerPortalLinks';
-export { isEnterpriseLearner } from './utils';
+export { ENTERPRISE_ADMIN, ENTERPRISE_CATALOG_ADMIN, ENTERPRISE_LEARNER, ENTERPRISE_OPENEDX_OPERATOR } from './constants';
+export { getSelectedEnterpriseUUID, isEnterpriseLearner, isEnterpriseUser } from './utils';

--- a/src/learnerPortalLinks.js
+++ b/src/learnerPortalLinks.js
@@ -1,5 +1,5 @@
 import { fetchEnterpriseCustomers } from './service';
-import { isEnterpriseLearner } from './utils';
+import { isEnterpriseUser } from './utils';
 
 function getCacheKey(userId) {
   return `learnerPortalLinks:${userId}`;
@@ -32,8 +32,6 @@ async function fetchLearnerPortalLinks(apiClient, userId) {
       const brandingConfiguration = enterpriseCustomer.branding_configuration;
       if (enableLearnerPortal && enterpriseCustomerSlug) {
         learnerPortalLinks.push({
-          title: `${enterpriseCustomer.name}`,
-          url: `${window.location.protocol}//${learnerPortalHostname}/${enterpriseCustomerSlug}`,
           // branding_configuration is not always returned as part
           // of the response so check if it exists before referencing fields
           branding_configuration: brandingConfiguration ? {
@@ -41,6 +39,9 @@ async function fetchLearnerPortalLinks(apiClient, userId) {
             banner_border_color: brandingConfiguration.banner_border_color || null,
             banner_background_color: brandingConfiguration.banner_background_color || null,
           } : null,
+          title: enterpriseCustomer.name,
+          url: `${window.location.protocol}//${learnerPortalHostname}/${enterpriseCustomerSlug}`,
+          uuid: enterpriseCustomer.uuid,
         });
       }
     }
@@ -73,7 +74,7 @@ function getCachedLearnerPortalLinks(userId) {
 export default async function getLearnerPortalLinks(apiClient, authenticatedUser) {
   let learnerPortalLinks = [];
 
-  if (authenticatedUser !== null && isEnterpriseLearner(authenticatedUser)) {
+  if (authenticatedUser !== null && isEnterpriseUser(authenticatedUser)) {
     const { userId } = authenticatedUser;
     const cachedLinks = getCachedLearnerPortalLinks(userId);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,19 @@
-// eslint-disable-next-line import/prefer-default-export
+import {
+  ENTERPRISE_ADMIN,
+  ENTERPRISE_CATALOG_ADMIN,
+  ENTERPRISE_LEARNER,
+  ENTERPRISE_OPENEDX_OPERATOR,
+} from './constants';
+
+const permissions = [
+  ENTERPRISE_ADMIN,
+  ENTERPRISE_CATALOG_ADMIN,
+  ENTERPRISE_LEARNER,
+  ENTERPRISE_OPENEDX_OPERATOR,
+];
+
+const isEnterpriseRole = role => permissions.some(permission => role.includes(permission));
+
 export function isEnterpriseLearner(user) {
   if (user !== null && user.roles) {
     const { roles } = user;
@@ -8,6 +23,33 @@ export function isEnterpriseLearner(user) {
       }
     }
   }
-
   return false;
+}
+
+export function isEnterpriseUser(user) {
+  if (user !== null && user.roles) {
+    const { roles } = user;
+    return roles.filter(role => isEnterpriseRole(role)).length > 0;
+  }
+  return false;
+}
+
+export function getSelectedEnterpriseUUID(user) {
+  /**
+   * Selected Enterprise UUID is the UUID of the User's chosen Enterprise that
+   * they are affiliated with if belonging to multiple. The user.roles array is
+   * sorted where the earlier occuring element is the selected one where active=true.
+   */
+  if (user !== null && user.roles) {
+    const { roles } = user;
+    const filteredRole = roles.find(role => isEnterpriseRole(role));
+    if (filteredRole) {
+      const splitRole = roles[0].split(':');
+      // A size of 2 indicates a successful split [0] being the role, [1] being the UUID
+      if (splitRole.length === 2) {
+        return splitRole[1];
+      }
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
Used to get the UUID from a user's roles that match `enterprise_learner` as the first matching one is the selected and active enterprise for that user.

Usage example:
```
getLearnerPortalLinks(httpClient, authenticatedUser).then((learnerPortalLinks) => {
  const preferredUUID = getPreferredEnterpriseUUID(authenticatedUser);
  const preferredLearnerPortalLink = learnerPortalLinks.find(learnerPortalLink => learnerPortalLink.uuid == preferredUUID);
});
```