### PR TITLE
fix: make react an external during webpack build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@edx/frontend-enterprise",
   "version": "1.0.0-semantically-released",
   "description": "Frontend utilities for supporting enterprise features.",
-  "main": "dist/main.js",
+  "main": "dist/index.js",
   "publishConfig": {
     "access": "public"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,8 +9,12 @@ module.exports = {
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
+    filename: 'index.js',
     libraryTarget: 'umd',
     globalObject: 'typeof self !== \'undefined\' ? self : this',
+  },
+  externals: {
+    react: 'react',
   },
   resolve: {
     extensions: ['.js', '.jsx'],


### PR DESCRIPTION
react should not be included in the built artifact, even though it's a dev dependency, because this package is installed into applications that install their own react dependency.

Also points webpack output at `dist/index.js` so that our frontend-build library can recognize the local module at the "usual" place: https://github.com/edx/frontend-build#local-module-configuration-for-webpack