### PR TITLE
fix: only fetch user's preferred enterprise metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6254,8 +6254,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -16084,6 +16083,16 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "query-string": {
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.2.tgz",
+      "integrity": "sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
+    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -17642,6 +17651,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -17779,6 +17793,11 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
   "peerDependencies": {
     "react": "^16.13.1",
     "@edx/frontend-platform": "^1.5.2"
+  },
+  "dependencies": {
+    "query-string": "^6.13.2"
   }
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
 import getLearnerPortalLinks from './learnerPortalLinks';
-import { getSelectedEnterpriseUUID } from './utils';
 
 export default function useEnterpriseConfig(authenticatedUser, learnerPortalHostname, lmsBaseUrl) {
   const [enterpriseLearnerPortalLink, setEnterpriseLearnerPortalLink] = useState();
@@ -16,9 +16,7 @@ export default function useEnterpriseConfig(authenticatedUser, learnerPortalHost
         learnerPortalHostname,
         lmsBaseUrl,
       ).then((learnerPortalLinks) => {
-        const preferredUUID = getSelectedEnterpriseUUID(authenticatedUser);
-        const preferredLearnerPortalLink = learnerPortalLinks.find(learnerPortalLink =>
-          learnerPortalLink.uuid === preferredUUID);
+        const preferredLearnerPortalLink = learnerPortalLinks.pop();
         if (preferredLearnerPortalLink) {
           const config = {
             logoAltText: preferredLearnerPortalLink.title,

--- a/src/learnerPortalLinks.js
+++ b/src/learnerPortalLinks.js
@@ -1,5 +1,5 @@
 import { fetchEnterpriseCustomers } from './service';
-import { isEnterpriseUser } from './utils';
+import { isEnterpriseUser, getSelectedEnterpriseUUID } from './utils';
 
 function getCacheKey(userId) {
   return `learnerPortalLinks:${userId}`;
@@ -19,6 +19,7 @@ function cacheLinks(userId, links) {
 async function fetchLearnerPortalLinks(
   apiClient,
   userId,
+  preferredEnterpriseUUID,
   learnerPortalHostname = process.env.ENTERPRISE_LEARNER_PORTAL_HOSTNAME,
   lmsBaseUrl = process.env.LMS_BASE_URL,
 ) {
@@ -26,7 +27,7 @@ async function fetchLearnerPortalLinks(
   if (!learnerPortalHostname) {
     return learnerPortalLinks;
   }
-  const response = await fetchEnterpriseCustomers(apiClient, lmsBaseUrl);
+  const response = await fetchEnterpriseCustomers(apiClient, lmsBaseUrl, preferredEnterpriseUUID);
   const enterpriseCustomers = response.data.results;
   try {
     for (let i = 0; i < enterpriseCustomers.length; i += 1) {
@@ -88,12 +89,14 @@ export default async function getLearnerPortalLinks(
     const { userId } = authenticatedUser;
     const cachedLinks = getCachedLearnerPortalLinks(userId);
 
-    if (cachedLinks != null) {
+    if (cachedLinks) {
       learnerPortalLinks = learnerPortalLinks.concat(cachedLinks);
     } else {
+      const preferredEnterpriseUUID = getSelectedEnterpriseUUID(authenticatedUser);
       const links = await fetchLearnerPortalLinks(
         apiClient,
         userId,
+        preferredEnterpriseUUID,
         learnerPortalHostname,
         lmsBaseUrl,
       );

--- a/src/service.js
+++ b/src/service.js
@@ -1,4 +1,19 @@
-const fetchEnterpriseCustomers = (apiClient, lmsBaseUrl = process.env.LMS_BASE_URL) => apiClient.get(`${lmsBaseUrl}/enterprise/api/v1/enterprise-customer/`);
+import qs from 'querystring';
+
+const fetchEnterpriseCustomers = (
+  apiClient,
+  lmsBaseUrl = process.env.LMS_BASE_URL,
+  preferredEnterpriseUUID = null,
+) => {
+  let url = `${lmsBaseUrl}/enterprise/api/v1/enterprise-customer/`;
+  if (preferredEnterpriseUUID !== null) {
+    const queryParams = qs.stringify({
+      uuid: preferredEnterpriseUUID,
+    });
+    url += `?${queryParams}`;
+  }
+  return apiClient.get(url);
+};
 
 // eslint-disable-next-line import/prefer-default-export
 export { fetchEnterpriseCustomers };


### PR DESCRIPTION
Pass the user's "preferred" enterprise uuid to the API call to `/enterprise-customer/` to prevent a paginated response.

**Testing instructions**
1. Install this branch of your local checkout of @edx/frontend-enterprise into a consuming MFE (e.g., frontend-app-learning).
2. Observe a network request to `/enterprise-customer/` which includes the `uuid` query parameter.