### PR TITLE
feat: eslint-plugin-import dependency upgrade

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,8 +8,8 @@ frontend-enterprise contains utility functions for supporting enterprise feature
 Dependency notes
 -----
 
-v6 and higher of query-string will fail the es5 check
-eslint-plugin-import needed at least 2.22.1 to avoid failures with an infinity symbol (see https://stackoverflow.com/questions/64790681/eslint-error-configuration-for-rule-import-no-cycle-is-invalid)
+* v6 and higher of query-string will fail the es5 check
+* eslint-plugin-import needed at least 2.22.1 to avoid failures with an infinity symbol (see https://stackoverflow.com/questions/64790681/eslint-error-configuration-for-rule-import-no-cycle-is-invalid). This can be removed from here once frontend-build PR is merged: https://github.com/edx/frontend-build/pull/137
 
 There is a precommit plugin (commitlint) which requires commit messages formatted in a particular way
 See: https://github.com/conventional-changelog/commitlint#what-is-commitlint.


### PR DESCRIPTION
Just readme change, prior release for pull/21 did not work due to either github creds or commit related issue. Trying new PR with correctly formatted commit message