### PR TITLE
fix: Adding testing during release for coveralls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
           node-version: 12
       - name: Install dependencies
         run: npm ci
-      - name: Build
-        run: npm run build
+      - name: Test
+        run: npm run test
+      - name: Coveralls
+        run: npm run coveralls
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
         run: npm run semantic-release
-      - name: Coveralls
-        run: npm run coveralls


### PR DESCRIPTION
Adding testing step during releases to get coverage for coveralls
Also removed the explicit npm build step as semantic-release already builds