### PR TITLE
chore: Switch coveralls to use official github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,8 @@ jobs:
       - name: Test
         run: npm run test
       - name: Coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run coveralls
+        uses: coverallsapp/github-action@master
+        with: github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
One more try - going to use the github action provided by coveralls