### PR TITLE
fix: upgrade react-instantsearch-dom to 6.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25259,27 +25259,27 @@
       }
     },
     "react-instantsearch-core": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.8.2.tgz",
-      "integrity": "sha512-UdAjcNIXb2mSECEDS/2XuB4W6rcbnph1NjJBUpY5TLLzSCdKXNTzS2PxF5hkdeuY0L/m/hvDQX6YqxV28PqKLA==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-core/-/react-instantsearch-core-6.8.3.tgz",
+      "integrity": "sha512-pRmWQsXz96t4QbrgH1WZRW0+EFNJ/08ckxSX5HsXfxLUL0myljc0/X2cSWgc7v0oJtwgDuy90vgn9C3S2TlErA==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "^3.1.0",
-        "prop-types": "^15.5.10",
+        "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0"
       }
     },
     "react-instantsearch-dom": {
-      "version": "6.8.2",
-      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.8.2.tgz",
-      "integrity": "sha512-d6YBsjW/aF3qzul7qqUV/KuzEFPVxlAZm3QhREPqMvOyrPTnG5itZZBLe7sFm9OKJ/8shR4TyNp3hb94as7COg==",
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/react-instantsearch-dom/-/react-instantsearch-dom-6.8.3.tgz",
+      "integrity": "sha512-+Z0zgARvnfDbMnPIZX8CfwKE+TCX7E751Ty4RDnjnmpgnrfYzoodMr4/By/3vZ2KRk308gpyx9yyXZ18/3Ay/g==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "algoliasearch-helper": "^3.1.0",
         "classnames": "^2.2.5",
-        "prop-types": "^15.5.10",
+        "prop-types": "^15.6.2",
         "react-fast-compare": "^3.0.0",
-        "react-instantsearch-core": "^6.8.2"
+        "react-instantsearch-core": "^6.8.3"
       }
     },
     "react-intl": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@fortawesome/react-fontawesome": "^0.1.4",
     "classnames": "^2.2.5",
     "query-string": "^5.1.1",
-    "react-instantsearch-dom": "^6.8.2",
+    "react-instantsearch-dom": "^6.8.3",
     "react-loading-skeleton": "^2.1.1"
   }
 }


### PR DESCRIPTION
This brings in an upstream fix/contribution to `react-instantsearch-dom` as described here: https://github.com/algolia/react-instantsearch/pull/3003