### PR TITLE
Add tests and run coveralls on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,7 @@ jobs:
       run: npm run lint
     - name: Test
       run: npm run test
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/course-search/ClearCurrentRefinements.jsx
+++ b/src/course-search/ClearCurrentRefinements.jsx
@@ -4,6 +4,8 @@ import { Button } from '@edx/paragon';
 import { SearchContext } from './SearchContext';
 import { clearRefinementsAction } from './data/actions';
 
+export const CLEAR_ALL_TEXT = 'clear all';
+
 const ClearCurrentRefinements = ({ className, variant }) => {
   const { dispatch } = useContext(SearchContext);
 
@@ -22,7 +24,7 @@ const ClearCurrentRefinements = ({ className, variant }) => {
       variant={variant}
       onClick={handleClearAllRefinementsClick}
     >
-      clear all
+      {CLEAR_ALL_TEXT}
     </Button>
   );
 };

--- a/src/course-search/tests/ClearCurrentRefinements.test.jsx
+++ b/src/course-search/tests/ClearCurrentRefinements.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import ClearCurrentRefinements, { CLEAR_ALL_TEXT } from '../ClearCurrentRefinements';
+
+import { renderWithRouter } from '../../utils/tests';
+import * as actions from '../data/actions';
+import SearchData from '../SearchContext';
+
+describe('<ClearCurrentRefinements />', () => {
+  test('renders the clear all button', () => {
+    renderWithRouter(<SearchData><ClearCurrentRefinements variant="primary" /></SearchData>);
+
+    expect(screen.queryByText(CLEAR_ALL_TEXT)).toBeInTheDocument();
+  });
+
+  test('dispatches the clear refinements action on click', async () => {
+    const spy = jest.spyOn(actions, 'clearRefinementsAction');
+    renderWithRouter(<SearchData><ClearCurrentRefinements /></SearchData>);
+
+    // click a specific refinement to remove it
+    fireEvent.click(screen.queryByText(CLEAR_ALL_TEXT));
+
+    // assert the clicked refinement in the url is removed but others stay put
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Adds tests to hopefully fix the drop in % test coverage that happened when I removed the hook.
Has coveralls run on PRs, because if it's going to fail the build, I want to know before merge.