### PR TITLE
fix: clean up facet pill styles

### DIFF
--- a/src/course-search/FacetItem.jsx
+++ b/src/course-search/FacetItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Input, Dropdown } from '@edx/paragon';
+import { Badge, Input, Dropdown } from '@edx/paragon';
 import classNames from 'classnames';
 import { STYLE_VARIANTS } from '../constants';
 
@@ -18,13 +18,15 @@ const FacetItem = ({
       {item.label}
     </span>
     {item.count && (
-      <span className={classNames(
-        'badge badge-pill ml-2 py-1 bg-brand-primary text-brand-primary',
-        { 'bg-brand-primary--default': variant === STYLE_VARIANTS.default },
-      )}
+      <Badge
+        pill
+        className={classNames(
+          'ml-2 bg-brand-primary text-brand-primary',
+          { 'bg-brand-primary--default': variant === STYLE_VARIANTS.default },
+        )}
       >
         {item.count}
-      </span>
+      </Badge>
     )}
   </Dropdown.Item>
 );

--- a/src/course-search/SearchBox.jsx
+++ b/src/course-search/SearchBox.jsx
@@ -40,7 +40,7 @@ export const SearchBoxBase = ({
   return (
     <div className={className}>
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-      <label id="search-input-box" className="fe__searchfield-input-box">
+      <label id="search-input-box" className="fe__searchfield-input-box text-brand-primary">
         {searchText}
       </label>
       <SearchField.Advanced

--- a/src/course-search/styles/_FacetList.scss
+++ b/src/course-search/styles/_FacetList.scss
@@ -26,7 +26,7 @@ $facet-dropdown-max-height: 250px;
         padding-left: 30px;
         white-space: break-spaces;
         display: flex;
-        align-items: center;
+        align-items: flex-start;
       }
     }
   }


### PR DESCRIPTION
## Current

![image](https://user-images.githubusercontent.com/2828721/114934510-f823fd80-9e07-11eb-8f15-1ee081646549.png)

## Updated
![image](https://user-images.githubusercontent.com/2828721/114934495-f2c6b300-9e07-11eb-8ff9-14a06cff7bf3.png)

Note the pill is 4px shorter. Also, both the checkbox and pill are top-aligned to the facet item, rather than awkwardly being centered.