### PR TITLE
fix: replacing query string parse with built in functionality

### DIFF
--- a/src/course-search/config/index.js
+++ b/src/course-search/config/index.js
@@ -1,15 +1,9 @@
-import qs from 'query-string';
-
 import {
   FEATURE_ENROLL_WITH_CODES,
   FEATURE_LANGUAGE_FACET,
   FEATURE_PROGRAM_TITLES_FACET,
 } from '../../constants';
-
-const hasFeatureFlagEnabled = (featureFlag) => {
-  const { features } = qs.parse(window.location.search);
-  return features && features.split(',').includes(featureFlag);
-};
+import { hasFeatureFlagEnabled } from '../data/utils';
 
 const features = {
   ENROLL_WITH_CODES: process.env.FEATURE_ENROLL_WITH_CODES || hasFeatureFlagEnabled(FEATURE_ENROLL_WITH_CODES),

--- a/src/course-search/data/tests/utils.test.js
+++ b/src/course-search/data/tests/utils.test.js
@@ -2,6 +2,8 @@ import { SUBJECTS } from './constants';
 import {
   sortItemsByLabelAsc,
   updateRefinementsFromQueryParams,
+  paramsToObject,
+  hasFeatureFlagEnabled,
 } from '../utils';
 
 describe('sortItemsByLabelAsc', () => {
@@ -42,5 +44,33 @@ describe('updateRefinementsFromQueryParams', () => {
 
     const updatedRefinements = updateRefinementsFromQueryParams(refinements);
     expect(updatedRefinements).toEqual(expectedUpdatedRefinements);
+  });
+});
+
+describe('paramsToObject', () => {
+  test('it converts string to object', () => {
+    const url = new URL('http://ayylmao.com?foo=bar');
+    const searchParams = new URLSearchParams(url.search);
+    const endingObject = paramsToObject(searchParams);
+    expect(endingObject).toEqual({ foo: 'bar' });
+  });
+});
+
+describe('hasFeatureFlagEnabled', () => {
+  const { location } = window;
+
+  beforeAll(() => {
+    delete window.location;
+    window.location = { search: '?features=ayy,lmao' };
+  });
+
+  afterAll(() => {
+    window.location = location;
+  });
+
+  test('properly determines feature flags from query params', () => {
+    expect(hasFeatureFlagEnabled('ayy')).toEqual(true);
+    expect(hasFeatureFlagEnabled('lmao')).toEqual(true);
+    expect(hasFeatureFlagEnabled('foobar')).toEqual(false);
   });
 });

--- a/src/course-search/data/utils.js
+++ b/src/course-search/data/utils.js
@@ -12,3 +12,17 @@ export const updateRefinementsFromQueryParams = (refinements) => {
 
   return refinementsWithJoinedLists;
 };
+
+export function paramsToObject(entries) {
+  const result = {};
+  entries.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}
+
+export function hasFeatureFlagEnabled(featureFlag) {
+  const searchParams = new URLSearchParams(window.location.search);
+  const { features } = paramsToObject(searchParams);
+  return features && features.split(',').includes(featureFlag);
+}


### PR DESCRIPTION
In order to appease `is-es5`, we need to replace the functionality of `query-string`'s `parse` method with the compatible `URLSearchParams` interface. In order to perfectly match behaviors, I've added a util function to convert the `URLSearchParams` object to a native dictionary.