### PR TITLE
fix: replacing query-string with built in functionality

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,6 @@ frontend-enterprise contains utility functions for supporting enterprise feature
 Dependency notes
 -----
 
-* v6 and higher of query-string will fail the es5 check
 * eslint-plugin-import needed at least 2.22.1 to avoid failures with an infinity symbol (see https://stackoverflow.com/questions/64790681/eslint-error-configuration-for-rule-import-no-cycle-is-invalid). This can be removed from here once frontend-build PR is merged: https://github.com/edx/frontend-build/pull/137
 
 There is a precommit plugin (commitlint) which requires commit messages formatted in a particular way
@@ -22,7 +21,7 @@ type must be one of [build, ci, docs, feat, fix, perf, refactor, revert, style, 
 
 Versioning and Releases
 -----
-This library has its version automatically updated by semantic-versioning when the release is published to npm. The source code package.json file should remain at "1.0.0-semantically-released".  The below Usage instructions will install the latest version from npm. Please see the repository Releases for earlier package versions. 
+This library has its version automatically updated by semantic-versioning when the release is published to npm. The source code package.json file should remain at "1.0.0-semantically-released".  The below Usage instructions will install the latest version from npm. Please see the repository Releases for earlier package versions.
 
 Preview next release version from Pull Requests
 *****

--- a/package-lock.json
+++ b/package-lock.json
@@ -22830,6 +22830,7 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "lodash.debounce": "^4.0.8",
     "npm-watch": "0.6.0",
     "prop-types": "15.7.2",
-    "query-string": "^5.1.1",
     "react": "16.14.0",
     "react-dom": "17.0.1",
     "react-instantsearch-dom": "^6.8.3",

--- a/src/course-search/SearchContext.jsx
+++ b/src/course-search/SearchContext.jsx
@@ -3,11 +3,10 @@ import React, {
 } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation, useHistory } from 'react-router-dom';
-import qs from 'query-string';
 import { BOOLEAN_FILTERS, SEARCH_FACET_FILTERS } from './data/constants';
 import { refinementsReducer } from './data/reducer';
 import { setMultipleRefinementsAction } from './data/actions';
-import { updateRefinementsFromQueryParams } from './data/utils';
+import { paramsToObject, stringifyRefinements, updateRefinementsFromQueryParams } from './data/utils';
 import { useIsFirstRender } from '../hooks';
 
 export const SearchContext = createContext();
@@ -37,8 +36,7 @@ const SearchData = ({ children, searchFacetFilters }) => {
   const { search } = useLocation();
   const history = useHistory();
 
-  const queryParams = useMemo(() => qs.parse(search), [search]);
-
+  const queryParams = useMemo(() => paramsToObject(new URLSearchParams(search)), [search]);
   useEffect(() => {
     const activeFacetAttributes = searchFacetFilters.map(filter => filter.attribute);
     const refinementsToSet = getRefinementsToSet(queryParams, activeFacetAttributes);
@@ -47,7 +45,7 @@ const SearchData = ({ children, searchFacetFilters }) => {
 
   const newQueryString = useMemo(() => {
     const refinementsWithJoinedLists = updateRefinementsFromQueryParams(refinementsFromQueryParams);
-    return qs.stringify(refinementsWithJoinedLists);
+    return stringifyRefinements(refinementsWithJoinedLists);
   }, [refinementsFromQueryParams]);
 
   const isFirstRender = useIsFirstRender();

--- a/src/course-search/data/utils.js
+++ b/src/course-search/data/utils.js
@@ -13,6 +13,15 @@ export const updateRefinementsFromQueryParams = (refinements) => {
   return refinementsWithJoinedLists;
 };
 
+export function stringifyRefinements(refinements) {
+  let refinementString = new URLSearchParams(refinements).toString();
+  // URLSearchParams won't encode spaces contained within individual refinements- ie `Computer Science`
+  if (refinementString) {
+    refinementString = refinementString.replace(/[+]/g, '%20');
+  }
+  return refinementString;
+}
+
 export function paramsToObject(entries) {
   const result = {};
   entries.forEach((value, key) => {


### PR DESCRIPTION
In an effort to allow filter work to be es5 compatible, this PR is removing another instance of `query-string` which has presumably been causing headaches with polyfills.