### PR TITLE
fix: disable side effects to not bundle all of the react testing library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@edx/frontend-enterprise",
+  "sideEffects": false,
   "version": "1.0.0-semantically-released",
   "description": "Frontend utilities for supporting enterprise features.",
   "main": "dist/",


### PR DESCRIPTION
`renderWithSearchContext` was being exported from `/utils/tests` but side effects were not disabled so our frontend apps were being bundled with all of the react test library