### PR TITLE
fix: updates to release config for Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Run Lerna Bootstrap
         run: npm run bootstrap
       - name: Lint
-        run: npm run ci:lint
+        run: npm run lint
       - name: Test
-        run: npm run ci:test
+        run: npm run test
       - name: Coverage Report
         uses: codecov/codecov-action@v1
       - name: Build
-        run: npm run ci:build
+        run: npm run build
       - name: Preview Changed Packages
         run: npm run changed
       - name: Publish Changed Packages

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "lerna run lint --stream",
     "lint:fix": "lerna run lint:fix --include-dependencies --include-dependents --since origin/master --stream",
     "ci:lint": "lerna run lint --include-dependencies --include-dependents --since origin/master --stream",
-    "publish": "lerna publish --yes --stream",
+    "publish": "lerna publish --yes",
     "changed": "lerna changed",
     "commitmsg": "commitlint -e $GIT_PARAMS"
   },


### PR DESCRIPTION
On the first attempt to publish to the 3 packages to NPM, the running of lint, test, and build commands was previously only running packages that have changed since `origin/master` to avoid running things for packages that did not change.

However, since the refactor PR merged to `master`, the commit is equal with `origin/master` so Lerna deems that no changes have occurred:

![image](https://user-images.githubusercontent.com/2828721/117309026-0df97100-ae50-11eb-9fb1-d7249c2d0156.png)

Also, it turns out `lerna publish` does not accept the `--stream`` argument so this PR also removes that.