### PR TITLE
fix: add git author identity with setup-git-user action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: fregante/setup-git-user@v1
       - name: Setup Nodejs
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
On merge to `master`, we are seeing an error from `lerna publish` where it expects the Git author identity to be known. To fix this, I included a new Github Action `fregante/setup-git-user@v1` to update the git config with the Github Actions user. I wanted to try using this action before manually running the `git config` commands ourselves.

This is only needed for release.yml as ci.yml does not publish or call any git commands.

```
lerna ERR! Author identity unknown
lerna ERR! 
lerna ERR! *** Please tell me who you are.
lerna ERR! 
lerna ERR! Run
lerna ERR! 
lerna ERR!   git config --global user.email "you@example.com"
lerna ERR!   git config --global user.name "Your Name"
lerna ERR! 
lerna ERR! to set your account's default identity.
```