### PR TITLE
fix: run lerna commands for all packages regardless of whether they changed in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,14 +25,14 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}" >> .npmrc
           npm whoami
       - name: Install and Setup Dependencies
-        run: npm run ci:setup
+        run: npm run setup
       # build must come before running linting and tests for the `dist` directory to exist.
       - name: Build
-        run: npm run ci:build
+        run: npm run build
       - name: Lint
-        run: npm run ci:lint
+        run: npm run lint
       - name: Test
-        run: npm run ci:test
+        run: npm run test
       - name: Coverage Report
         uses: codecov/codecov-action@v1
       - name: Preview Changed Packages

--- a/packages/catalog-search/CHANGELOG.md
+++ b/packages/catalog-search/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.5](https://github.com/edx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@0.1.4...@edx/frontend-enterprise-catalog-search@0.1.5) (2021-05-10)
-
-
-### Bug Fixes
-
-* update publishing behavior and add additional docs ([#104](https://github.com/edx/frontend-enterprise/issues/104)) ([525c430](https://github.com/edx/frontend-enterprise/commit/525c430d5027e4514a27edccfed3d6ed4ddae091))
-
-
-
-
-
 ## [0.1.4](https://github.com/edx/frontend-enterprise/compare/@edx/frontend-enterprise-catalog-search@0.1.3...@edx/frontend-enterprise-catalog-search@0.1.4) (2021-05-08)
 
 **Note:** Version bump only for package @edx/frontend-enterprise-catalog-search

--- a/packages/catalog-search/package-lock.json
+++ b/packages/catalog-search/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@edx/frontend-enterprise-catalog-search",
-	"version": "0.1.5",
+	"version": "0.1.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/catalog-search/package.json
+++ b/packages/catalog-search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-catalog-search",
-  "version": "0.1.5",
+  "version": "0.1.4",
   "description": "Components related to Enterprise catalog search.",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^0.1.4",
+    "@edx/frontend-enterprise-utils": "^0.1.3",
     "classnames": "2.2.5",
     "lodash.debounce": "4.0.8",
     "prop-types": "15.6.2"
@@ -54,8 +54,8 @@
     "@testing-library/react": "11.2.6",
     "@testing-library/react-hooks": "3.4.2",
     "@testing-library/user-event": "13.1.8",
-    "npm-watch": "^0.9.0",
-    "react-instantsearch-dom": "6.8.3"
+    "react-instantsearch-dom": "6.8.3",
+    "npm-watch": "^0.9.0"
   },
   "peerDependencies": {
     "@edx/frontend-platform": "1.9.6",

--- a/packages/logistration/CHANGELOG.md
+++ b/packages/logistration/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.4](https://github.com/edx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@0.1.3...@edx/frontend-enterprise-logistration@0.1.4) (2021-05-10)
-
-
-### Bug Fixes
-
-* update publishing behavior and add additional docs ([#104](https://github.com/edx/frontend-enterprise/issues/104)) ([525c430](https://github.com/edx/frontend-enterprise/commit/525c430d5027e4514a27edccfed3d6ed4ddae091))
-
-
-
-
-
 ## [0.1.3](https://github.com/edx/frontend-enterprise/compare/@edx/frontend-enterprise-logistration@0.1.2...@edx/frontend-enterprise-logistration@0.1.3) (2021-05-08)
 
 **Note:** Version bump only for package @edx/frontend-enterprise-logistration

--- a/packages/logistration/package-lock.json
+++ b/packages/logistration/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@edx/frontend-enterprise-logistration",
-	"version": "0.1.4",
+	"version": "0.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-logistration",
-  "version": "0.1.4",
+  "version": "0.1.3",
   "description": "Enterprise-specific component(s) to ensure enterprise users are redirected to branded enterprise logistration flow.",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@edx/frontend-enterprise-utils": "^0.1.4",
+    "@edx/frontend-enterprise-utils": "^0.1.3",
     "prop-types": "15.7.2",
     "query-string": "7.0.0"
   },

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.4](https://github.com/edx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@0.1.3...@edx/frontend-enterprise-utils@0.1.4) (2021-05-10)
-
-
-### Bug Fixes
-
-* update publishing behavior and add additional docs ([#104](https://github.com/edx/frontend-enterprise/issues/104)) ([525c430](https://github.com/edx/frontend-enterprise/commit/525c430d5027e4514a27edccfed3d6ed4ddae091))
-
-
-
-
-
 ## [0.1.3](https://github.com/edx/frontend-enterprise/compare/@edx/frontend-enterprise-utils@0.1.2...@edx/frontend-enterprise-utils@0.1.3) (2021-05-08)
 
 **Note:** Version bump only for package @edx/frontend-enterprise-utils

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@edx/frontend-enterprise-utils",
-	"version": "0.1.4",
+	"version": "0.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/frontend-enterprise-utils",
-  "version": "0.1.4",
+  "version": "0.1.3",
   "description": "Utils and other miscellaneous enterprise things.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The previous merged PR incorrectly used the NPM commands meant for ci.yml, which tells Lerna to only run commands for packages that have changed since `origin/master`. This PR swaps back to running Lerna commands for all packages instead since once a PR is merged, it _is_ even with `origin/master` and won't release anything.

I deleted the most recent git tags Lerna created related to the last release attempt and reverted the previous "chore: publish" commit since Lerna should re-commit those changes once this PR is merged.