### PR TITLE
test: add algolia mock and search filters test

### DIFF
--- a/packages/catalog-search/__mocks__/react-instantsearch-dom.jsx
+++ b/packages/catalog-search/__mocks__/react-instantsearch-dom.jsx
@@ -1,0 +1,71 @@
+/* eslint-disable object-curly-newline */
+/* eslint-disable react/prop-types */
+import React from 'react';
+
+const MockReactInstantSearch = jest.genMockFromModule(
+  'react-instantsearch-dom',
+);
+
+// eslint-disable-next-line camelcase
+const advertised_course_run = {
+  start: '2020-09-09T04:00:00Z',
+  key: 'course-v1:edX+Bee101+3T2020',
+};
+
+const fakeHits = [
+  { objectID: '1', title: 'bla', advertised_course_run, key: 'Bees101' },
+  { objectID: '2', title: 'blp', advertised_course_run, key: 'Wasps200' },
+];
+
+MockReactInstantSearch.connectStateResults = Component => (props) => (
+  <Component
+    searchResults={{
+      hits: fakeHits,
+      hitsPerPage: 25,
+      nbHits: 2,
+      nbPages: 1,
+      page: 1,
+    }}
+    isSearchStalled={false}
+    searchState={{
+      page: 1,
+    }}
+    {...props}
+  />
+);
+
+MockReactInstantSearch.connectPagination = Component => (props) => (
+  <Component nbPages={2} maxPagesDisplayed={2} {...props} />
+);
+
+MockReactInstantSearch.InstantSearch = ({ children }) => <div>{children}</div>;
+
+MockReactInstantSearch.connectCurrentRefinements = Component => (props) => (
+  <Component items={[]} {...props} />
+);
+
+MockReactInstantSearch.connectRefinementList = Component => (props) => (
+  <Component
+    attribute="subjects"
+    currentRefinement={[]}
+    items={[]}
+    refinementsFromQueryParams={{}}
+    title="Foo"
+    searchForItems={() => {}}
+    {...props}
+  />
+);
+
+MockReactInstantSearch.connectSearchBox = Component => (props) => (
+  <Component {...props} />
+);
+
+MockReactInstantSearch.connectPagination = Component => (props) => (
+  <Component nbPages={1} {...props} />
+);
+
+MockReactInstantSearch.InstantSearch = ({ children }) => <>{children}</>;
+MockReactInstantSearch.Configure = () => <div>CONFIGURED</div>;
+
+// It is necessary to export this way, or tests not using the mock will fail
+module.exports = MockReactInstantSearch;

--- a/packages/catalog-search/src/tests/SearchFilters.test.jsx
+++ b/packages/catalog-search/src/tests/SearchFilters.test.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { SEARCH_FACET_FILTERS } from '../data/constants';
+
+import { renderWithSearchContext } from './utils';
+
+import '../../__mocks__/react-instantsearch-dom';
+import SearchFilters from '../SearchFilters';
+
+describe('<SearchFilters />', () => {
+  test('renders with a label', () => {
+    renderWithSearchContext(<SearchFilters />);
+    SEARCH_FACET_FILTERS.forEach((filter) => {
+      expect(screen.getByText(filter.title)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Adds an algolia mock and a basic test that uses it. Should enable more conprehensive testing in the future!