### PR TITLE
fix: add hotjar to searchbox

### DIFF
--- a/packages/catalog-search/src/SearchBox.jsx
+++ b/packages/catalog-search/src/SearchBox.jsx
@@ -66,7 +66,7 @@ export const SearchBoxBase = ({
         onSubmit={handleSubmit}
         onClear={handleClear}
       >
-        <SearchField.Input className="form-control-lg" aria-labelledby="search-input-box" />
+        <SearchField.Input className="form-control-lg" aria-labelledby="search-input-box" data-hj-whitelist />
         <SearchField.ClearButton />
         <SearchField.SubmitButton />
       </SearchField.Advanced>


### PR DESCRIPTION
Adds the necessary tag for hotjar analytics.
Verified manually that the tag appears by using local `frontend-enterprise` on learner portal.