### PR TITLE
ci: use from-git vs from-package in lerna publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Changed Packages
-        run: lerna publish from-package --no-git-tag-version --no-push --yes
+        run: lerna publish from-git --no-git-tag-version --no-push --yes


### PR DESCRIPTION
In our current release.yml workflow for Github Actions, the following commands are run:

1. `lerna version`
2. `lerna publish from-package`

`lerna version` tells Lerna to determine which packages changed and which versions they should be bumped to based on conventional commits. It then creates a "chore: publish" commit to bump versions in package.json files, add CHANGELOG entires, push Git tags, etc.

Then, the assumption was that `lerna publish from-package` would pull the correct version numbers from the updated/committed `package.json` files however this does not seem to be the case as Lerna is still attempting to publish over existing versions.

This PR swaps to using `lerna publish from-git` instead which theoretically should do a better job at actually adhering to the version number(s) tagged for release by `lerna version` instead of an already existing NPM version.

Official docs: https://github.com/lerna/lerna/tree/main/commands/publish#bump-from-git