### PR TITLE
fix: add loadingDisplay prop to LoginRedirect

### DIFF
--- a/packages/logistration/src/LoginRedirect.jsx
+++ b/packages/logistration/src/LoginRedirect.jsx
@@ -11,7 +11,7 @@ import { getConfig } from '@edx/frontend-platform/config';
  *
  * @param {node} children The child nodes to render if there is an authenticated user.
  */
-export default function LoginRedirect({ children }) {
+export default function LoginRedirect({ children, loadingDisplay: LoadingDisplay }) {
   const config = getConfig();
   const user = getAuthenticatedUser();
 
@@ -27,9 +27,15 @@ export default function LoginRedirect({ children }) {
   const proxyLoginUrl = `${config.LMS_BASE_URL}/enterprise/proxy-login/?${qs.stringify(options)}`;
   global.location.href = proxyLoginUrl;
 
-  return null;
+  return LoadingDisplay;
 }
 
 LoginRedirect.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
+  loadingDisplay: PropTypes.element,
+};
+
+LoginRedirect.defaultProps = {
+  children: null,
+  loadingDisplay: null,
 };

--- a/packages/logistration/src/LoginRedirect.test.jsx
+++ b/packages/logistration/src/LoginRedirect.test.jsx
@@ -16,6 +16,12 @@ const LoginRedirectWithChild = () => (
   </LoginRedirect>
 );
 
+const LoginRedirectWithLoadingDisplay = () => (
+  <LoginRedirect
+    loadingDisplay={<span data-testid="did-i-render" />}
+  />
+);
+
 describe('LoginRedirect', () => {
   beforeEach(() => {
     getAuthenticatedUser.mockReset();
@@ -44,5 +50,15 @@ describe('LoginRedirect', () => {
     // assert children are not rendered
     expect(screen.queryByTestId('did-i-render')).not.toBeInTheDocument();
     // We don't test the redirect functionality explicitly as navigation is not currently supported by jsdom
+  });
+
+  test('render ``loadingDisplay`` element if provided and the user is not authenticated', async () => {
+    const Component = <LoginRedirectWithLoadingDisplay />;
+    renderWithRouter(Component, {
+      route: `/${TEST_ENTERPRISE_SLUG}`,
+    });
+
+    // assert ``loadingDisplay`` element is rendered
+    expect(screen.queryByTestId('did-i-render')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR is primarily a test of Lerna publishing now that we're using `lerna publish from-git`.

That said, this change is something I have in use locally (via module.config.js) for in-progress work related to Admin Portal login redirect behavior needing a way to display some custom UI while the user's account is being fetched.