### PR TITLE
ci: force publish from-package to get versions in sync with npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,5 @@ jobs:
         run: npm run test
       - name: Coverage Report
         uses: codecov/codecov-action@v1
-      - name: Push Updated Versions and Tags
-        run: lerna version --yes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish Changed Packages
-        run: lerna publish from-git --no-git-tag-version --no-push --yes
+      - name: Publish Packages
+        run: lerna publish from-package --yes


### PR DESCRIPTION
This is an intermediate step in resolving Lerna publishing issues. On a previous merged PR, Lerna did not correctly publish the latest tagged version to NPM for `@edx/frontend-enterprise-logistration` which means the published NPM version is behind the versions specified in the Git tag or package.json file.

Temporarily changing `lerna publish` to use `from-package` will publish the changes from this version to NPM, at which point we can try a different approach.