### PR TITLE
fix: downgrade query-string to pin to ES5 compatible version

### DIFF
--- a/packages/logistration/package-lock.json
+++ b/packages/logistration/package-lock.json
@@ -7614,11 +7614,6 @@
 				}
 			}
 		},
-		"filter-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
-		},
 		"finalhandler": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -14403,21 +14398,13 @@
 			"dev": true
 		},
 		"query-string": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.0.tgz",
-			"integrity": "sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 			"requires": {
 				"decode-uri-component": "^0.2.0",
-				"filter-obj": "^1.1.0",
-				"split-on-first": "^1.0.0",
-				"strict-uri-encode": "^2.0.0"
-			},
-			"dependencies": {
-				"strict-uri-encode": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-					"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
-				}
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
 			}
 		},
 		"querystring": {
@@ -16201,11 +16188,6 @@
 				}
 			}
 		},
-		"split-on-first": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -16404,8 +16386,7 @@
 		"strict-uri-encode": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-			"dev": true
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
 		"string-length": {
 			"version": "4.0.2",

--- a/packages/logistration/package.json
+++ b/packages/logistration/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@edx/frontend-enterprise-utils": "^0.1.6",
     "prop-types": "15.7.2",
-    "query-string": "7.0.0"
+    "query-string": "5.1.1"
   },
   "devDependencies": {
     "@edx/frontend-build": "5.6.14",

--- a/packages/utils/package-lock.json
+++ b/packages/utils/package-lock.json
@@ -7149,11 +7149,6 @@
 				}
 			}
 		},
-		"filter-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-			"integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
-		},
 		"finalhandler": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -11456,8 +11451,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -13235,14 +13229,13 @@
 			"dev": true
 		},
 		"query-string": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.0.tgz",
-			"integrity": "sha512-Iy7moLybliR5ZgrK/1R3vjrXq03S13Vz4Rbm5Jg3EFq1LUmQppto0qtXz4vqZ386MSRjZgnTSZ9QC+NZOSd/XA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
 			"requires": {
 				"decode-uri-component": "^0.2.0",
-				"filter-obj": "^1.1.0",
-				"split-on-first": "^1.0.0",
-				"strict-uri-encode": "^2.0.0"
+				"object-assign": "^4.1.0",
+				"strict-uri-encode": "^1.0.0"
 			}
 		},
 		"querystring": {
@@ -15082,11 +15075,6 @@
 				}
 			}
 		},
-		"split-on-first": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-			"integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
-		},
 		"split-string": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -15283,9 +15271,9 @@
 			"dev": true
 		},
 		"strict-uri-encode": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-			"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
 		},
 		"string-length": {
 			"version": "4.0.2",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@testing-library/react": "11.2.6",
     "history": "4.10.1",
-    "query-string": "7.0.0"
+    "query-string": "5.1.1"
   },
   "devDependencies": {
     "@edx/frontend-build": "5.6.14",


### PR DESCRIPTION
After installing `@edx/frontend-enterprise-utils` and `@edx/frontend-enterprise-logistration` in `frontend-app-admin-portal`, a PR's CI began failing on the `npm run is-es5` check, noting that some bit of the minified vendors bundle contains non-ES5 compatible code that didn't get transpiled.

2 of the packages in this repo use `query-string@7` which is known to not be natively compatible with ES5. Per the docs, downgrading to `query-string@5` may help to resolve this issue.