### PR TITLE
fix: improved support for lists of attribute values in Algolia facet filtering

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,9 @@
       "conventionalCommits": true,
       "createRelease": "github"
     }
+  },
+  "changelogPreset": {
+    "name": "conventionalcommits",
+    "issueUrlFormat": "{{host}}/{{owner}}/{{repository}}/issues/{{id}}"
   }
 }

--- a/packages/catalog-search/__mocks__/react-instantsearch-dom.jsx
+++ b/packages/catalog-search/__mocks__/react-instantsearch-dom.jsx
@@ -49,7 +49,7 @@ MockReactInstantSearch.connectRefinementList = Component => (props) => (
     attribute="subjects"
     currentRefinement={[]}
     items={[]}
-    refinementsFromQueryParams={{}}
+    refinements={{}}
     title="Foo"
     searchForItems={() => {}}
     {...props}

--- a/packages/catalog-search/src/ClearCurrentRefinements.jsx
+++ b/packages/catalog-search/src/ClearCurrentRefinements.jsx
@@ -11,7 +11,7 @@ const ClearCurrentRefinements = ({ className, variant, ...props }) => {
 
   /**
    * Called when clear filters button is clicked. Removes
-   * all non-query keys from refinementsFromQueryParams and
+   * all non-query keys from ``refinements`` and
    * updates the query params.
    */
   const handleClearAllRefinementsClick = () => {

--- a/packages/catalog-search/src/CurrentRefinements.jsx
+++ b/packages/catalog-search/src/CurrentRefinements.jsx
@@ -26,8 +26,7 @@ export const CurrentRefinementsBase = ({ items, variant }) => {
   }
 
   const [showAllRefinements, setShowAllRefinements] = useState(false);
-  const { refinementsFromQueryParams, dispatch } = useContext(SearchContext);
-
+  const { refinements, dispatch } = useContext(SearchContext);
   const activeRefinementsAsFlatArray = useActiveRefinementsAsFlatArray(items);
 
   /**
@@ -54,9 +53,8 @@ export const CurrentRefinementsBase = ({ items, variant }) => {
     }
     // if the refinement is found, remove it.
     const facetName = item.attribute;
-    if (!QUERY_PARAMS_TO_IGNORE.includes(facetName) && refinementsFromQueryParams[facetName]
-    && refinementsFromQueryParams[facetName].includes(item.label)) {
-      if (refinementsFromQueryParams[facetName].length === 1) {
+    if (!QUERY_PARAMS_TO_IGNORE.includes(facetName) && refinements[facetName]?.includes(item.label)) {
+      if (refinements[facetName].length === 1) {
         dispatch(deleteRefinementAction(facetName));
       } else {
         dispatch(removeFromRefinementArray(facetName, item.label));

--- a/packages/catalog-search/src/FacetListBase.jsx
+++ b/packages/catalog-search/src/FacetListBase.jsx
@@ -22,18 +22,17 @@ const FacetListBase = ({
   variant,
   noDisplay,
 }) => {
+  const { refinements, dispatch } = useContext(SearchContext);
+
   /**
-   * Handles when a facet option is toggled by either updating the appropriate
-   * query parameter for the facet attribute, or removes the facet attribute if
-   * there's no longer any selected options for that facet attribute.
+   * Handles when a facet option is toggled by either adding it to the refinements
+   * reducer for the facet attribute, or removes the facet attribute if there is no
+   * longer any selected options for that particular facet attribute.
    */
-
-  const { refinementsFromQueryParams, dispatch } = useContext(SearchContext);
-
   const handleInputOnChange = (item) => {
     if (item.value && facetValueType === 'array') {
       if (item.value.length > 0) {
-        if (refinementsFromQueryParams[attribute]?.includes(item.label)) {
+        if (refinements[attribute]?.includes(item.label)) {
           dispatch(removeFromRefinementArray(attribute, item.label));
         } else {
           dispatch(addToRefinementArray(attribute, item.label));
@@ -43,7 +42,7 @@ const FacetListBase = ({
       }
     } else if (facetValueType === 'bool') {
       // eslint-disable-next-line no-bitwise
-      dispatch(setRefinementAction(attribute, refinementsFromQueryParams[attribute] ^ 1));
+      dispatch(setRefinementAction(attribute, refinements[attribute] ^ 1));
     } else if (facetValueType === 'single-item') {
       dispatch(setRefinementAction(attribute, [item.label]));
     }
@@ -55,9 +54,8 @@ const FacetListBase = ({
         return <span className="p-2 d-block">{NO_OPTIONS_FOUND}</span>;
       }
 
-      return items.map(item => {
+      return items.map((item) => {
         const isChecked = isCheckedField ? item[isCheckedField] : !!item.value;
-
         return (
           <FacetItem
             key={item.label}

--- a/packages/catalog-search/src/FacetListRefinement.jsx
+++ b/packages/catalog-search/src/FacetListRefinement.jsx
@@ -18,7 +18,7 @@ FacetListRefinementBase.propTypes = {
   attribute: PropTypes.string.isRequired,
   currentRefinement: PropTypes.arrayOf(PropTypes.string).isRequired,
   items: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  refinementsFromQueryParams: PropTypes.shape().isRequired,
+  refinements: PropTypes.shape().isRequired,
   title: PropTypes.string.isRequired,
 };
 

--- a/packages/catalog-search/src/SearchFilters.jsx
+++ b/packages/catalog-search/src/SearchFilters.jsx
@@ -18,7 +18,7 @@ export const FREE_ALL_TITLE = 'Free / All';
 
 const SearchFilters = ({ variant }) => {
   const size = useWindowSize();
-  const { refinementsFromQueryParams, searchFacetFilters } = useContext(SearchContext);
+  const { refinements, searchFacetFilters } = useContext(SearchContext);
   const showMobileMenu = useMemo(
     () => size.width < breakpoints.small.maxWidth,
     [JSON.stringify(size)],
@@ -28,13 +28,13 @@ const SearchFilters = ({ variant }) => {
       label: 'Free to me',
       // flip the 1 to 0 or vice versa using boolean logic
       // eslint-disable-next-line no-bitwise
-      value: refinementsFromQueryParams[SHOW_ALL_NAME] ^ 1,
+      value: refinements[SHOW_ALL_NAME] ^ 1,
     },
     {
       label: 'All courses',
-      value: refinementsFromQueryParams[SHOW_ALL_NAME],
+      value: refinements[SHOW_ALL_NAME],
     },
-  ], [refinementsFromQueryParams[SHOW_ALL_NAME]]);
+  ], [refinements[SHOW_ALL_NAME]]);
 
   const searchFacets = useMemo(
     () => {
@@ -52,8 +52,8 @@ const SearchFilters = ({ variant }) => {
             }
             return items;
           }}
-          refinementsFromQueryParams={refinementsFromQueryParams}
-          defaultRefinement={refinementsFromQueryParams[attribute]}
+          refinements={refinements}
+          defaultRefinement={refinements[attribute]}
           facetValueType="array"
           typeaheadOptions={typeaheadOptions}
           searchable={!!typeaheadOptions}
@@ -78,7 +78,7 @@ const SearchFilters = ({ variant }) => {
         </>
       );
     },
-    [refinementsFromQueryParams],
+    [JSON.stringify(refinements)],
   );
 
   return (

--- a/packages/catalog-search/src/SearchHeader.jsx
+++ b/packages/catalog-search/src/SearchHeader.jsx
@@ -13,9 +13,8 @@ export const searchBoxColTestId = 'search-box-col';
 export const filtersColTestId = 'filters-col';
 
 const SearchHeader = ({ variant, containerSize }) => {
-  const { refinementsFromQueryParams } = useContext(SearchContext);
-
-  const searchQueryFromQueryParams = refinementsFromQueryParams.q;
+  const { refinements } = useContext(SearchContext);
+  const searchQueryFromRefinements = refinements.q;
 
   return (
     <div className="bg-brand-primary">
@@ -29,7 +28,7 @@ const SearchHeader = ({ variant, containerSize }) => {
           >
             <SearchBox
               className="mb-4"
-              defaultRefinement={searchQueryFromQueryParams}
+              defaultRefinement={searchQueryFromRefinements}
               variant={variant}
             />
           </Col>

--- a/packages/catalog-search/src/data/hooks.js
+++ b/packages/catalog-search/src/data/hooks.js
@@ -6,33 +6,33 @@ import { isNull } from '@edx/frontend-enterprise-utils';
    * with a list of that facet attribute's active selection(s).
    */
 export const useActiveRefinementsByAttribute = (items) => {
-  const refinementsFromQueryParamsByAttribute = useMemo(
+  const refinementsByAttribute = useMemo(
     () => {
-      const refinements = {};
+      const refinementsMap = {};
       items.forEach((facet) => {
         const { attribute } = facet;
-        refinements[attribute] = facet.items;
+        refinementsMap[attribute] = facet.items;
       });
-      return refinements;
+      return refinementsMap;
     },
     [items],
   );
 
-  return refinementsFromQueryParamsByAttribute;
+  return refinementsByAttribute;
 };
 
 /**
-   * Transforms refinementsFromQueryParamsByAttribute into a flat array of objects,
+   * Transforms refinementsByAttribute into a flat array of objects,
    * each with an attribute key so we can still associate which attribute
    * a refinement is for.
    */
 export const useActiveRefinementsAsFlatArray = (items) => {
-  const refinementsFromQueryParamsByAttribute = useActiveRefinementsByAttribute(items);
+  const refinementsByAttribute = useActiveRefinementsByAttribute(items);
 
-  const refinementsFromQueryParamsAsFlatArray = useMemo(
+  const refinementsAsFlatArray = useMemo(
     () => {
       const refinements = [];
-      Object.entries(refinementsFromQueryParamsByAttribute).forEach(([key, value]) => {
+      Object.entries(refinementsByAttribute).forEach(([key, value]) => {
         const updatedValue = value.map((item) => ({
           ...item,
           attribute: key,
@@ -41,10 +41,10 @@ export const useActiveRefinementsAsFlatArray = (items) => {
       });
       return refinements;
     },
-    [refinementsFromQueryParamsByAttribute],
+    [JSON.stringify(refinementsByAttribute)],
   );
 
-  return refinementsFromQueryParamsAsFlatArray;
+  return refinementsAsFlatArray;
 };
 
 export const useNbHitsFromSearchResults = (searchResults) => {

--- a/packages/catalog-search/src/data/tests/utils.test.js
+++ b/packages/catalog-search/src/data/tests/utils.test.js
@@ -1,8 +1,6 @@
-import { SUBJECTS } from './constants';
 import {
   sortItemsByLabelAsc,
-  updateRefinementsFromQueryParams,
-  paramsToObject,
+  searchParamsToObject,
   hasFeatureFlagEnabled,
 } from '../utils';
 
@@ -33,39 +31,25 @@ describe('sortItemsByLabelAsc', () => {
   });
 });
 
-describe('updateRefinementsFromQueryParams', () => {
-  test('returns the correctly updated refinements', () => {
-    const refinements = {
-      subjects: [SUBJECTS.COMPUTER_SCIENCE, SUBJECTS.COMMUNICATION],
-    };
-    const expectedUpdatedRefinements = {
-      subjects: `${SUBJECTS.COMPUTER_SCIENCE},${SUBJECTS.COMMUNICATION}`,
-    };
-
-    const updatedRefinements = updateRefinementsFromQueryParams(refinements);
-    expect(updatedRefinements).toEqual(expectedUpdatedRefinements);
-  });
-});
-
-describe('paramsToObject', () => {
+describe('searchParamsToObject', () => {
   test('it converts string to object', () => {
-    const url = new URL('http://ayylmao.com?foo=bar');
+    const url = new URL('http://ayylmao.com?foo=bar&foo=bar2');
     const searchParams = new URLSearchParams(url.search);
-    const endingObject = paramsToObject(searchParams);
-    expect(endingObject).toEqual({ foo: 'bar' });
+    const endingObject = searchParamsToObject(searchParams);
+    expect(endingObject).toEqual({ foo: ['bar', 'bar2'] });
   });
 });
 
 describe('hasFeatureFlagEnabled', () => {
-  const { location } = window;
+  const { location } = global;
 
   beforeAll(() => {
-    delete window.location;
-    window.location = { search: '?features=ayy,lmao' };
+    delete global.location;
+    global.location = { search: '?features=ayy&features=lmao' };
   });
 
   afterAll(() => {
-    window.location = location;
+    global.location = location;
   });
 
   test('properly determines feature flags from query params', () => {

--- a/packages/catalog-search/src/data/utils.js
+++ b/packages/catalog-search/src/data/utils.js
@@ -1,20 +1,28 @@
 export const sortItemsByLabelAsc = items => items.sort((a, b) => a.label.localeCompare(b.label));
 
-export const updateRefinementsFromQueryParams = (refinements) => {
-  const refinementsWithJoinedLists = {};
-  Object.entries(refinements).forEach(([key, value]) => {
-    let newValue = value;
-    if (Array.isArray(value)) {
-      newValue = value.join(',');
-    }
-    refinementsWithJoinedLists[key] = newValue;
-  });
-
-  return refinementsWithJoinedLists;
-};
-
+/**
+ * Takes an object containing the current refinements state and converts it
+ * to query parameter string that can be used to push onto the history stack.
+ *
+ * Refinements that contain more than 1 value will be handled accordingly, e.g.:
+ *   `{ foo: ['bar', 'bar2' ]}` will be parsed as `foo=bar&foo=bar2`
+ *
+ * @param {object} refinements
+ * @returns Query parameter string
+ */
 export function stringifyRefinements(refinements) {
-  let refinementString = new URLSearchParams(refinements).toString();
+  const params = new URLSearchParams();
+  Object.entries(refinements).forEach((tuple) => {
+    const [key, value] = tuple;
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        params.append(key, item);
+      });
+    } else {
+      params.append(key, value);
+    }
+  });
+  let refinementString = params.toString();
   // URLSearchParams won't encode spaces contained within individual refinements- ie `Computer Science`
   if (refinementString) {
     refinementString = refinementString.replace(/[+]/g, '%20');
@@ -22,16 +30,27 @@ export function stringifyRefinements(refinements) {
   return refinementString;
 }
 
-export function paramsToObject(entries) {
-  const result = {};
-  entries.forEach((value, key) => {
-    result[key] = value;
-  });
-  return result;
+/**
+ * Given a URLSearchParams instance, parses an object that accounts for the
+ * possibility of more than one value per parameter, e.g. "?foo=bar&foo=bar2".
+ *
+ * @param {*} entries URLSearchParams instance
+ * @returns Object containing query parameters with an array of values for each parameter.
+ */
+export function searchParamsToObject(entries) {
+  return [...entries].reduce((acc, tuple) => {
+    const [key, value] = tuple;
+    if (Object.prototype.hasOwnProperty.call(acc, key)) {
+      acc[key] = [...acc[key], value];
+    } else {
+      acc[key] = [value];
+    }
+    return acc;
+  }, {});
 }
 
 export function hasFeatureFlagEnabled(featureFlag) {
-  const searchParams = new URLSearchParams(window.location.search);
-  const { features } = paramsToObject(searchParams);
-  return features && features.split(',').includes(featureFlag);
+  const searchParams = new URLSearchParams(global.location.search);
+  const { features } = searchParamsToObject(searchParams);
+  return features?.includes(featureFlag);
 }

--- a/packages/catalog-search/src/tests/CurrentRefinements.test.jsx
+++ b/packages/catalog-search/src/tests/CurrentRefinements.test.jsx
@@ -65,7 +65,7 @@ describe('<CurrentRefinements />', () => {
         <CurrentRefinementsBase items={items} />
       </SearchData>,
       {
-        route: `/?subjects=${SUBJECTS.COMPUTER_SCIENCE},${SUBJECTS.COMMUNICATION}`,
+        route: `/?subjects=${SUBJECTS.COMPUTER_SCIENCE}&subjects=${SUBJECTS.COMMUNICATION}`,
       },
     );
 

--- a/packages/catalog-search/src/tests/FacetListBase.test.jsx
+++ b/packages/catalog-search/src/tests/FacetListBase.test.jsx
@@ -31,7 +31,7 @@ const propsWithItems = {
     value: 0,
   },
   ],
-  refinementsFromQueryParams: {
+  refinements: {
     [FACET_ATTRIBUTES.SUBJECTS]: [SUBJECTS.COMMUNICATION],
     page: 3,
   },
@@ -142,11 +142,15 @@ describe('<FacetListBase />', () => {
     });
 
     // assert page was deleted and subjects were not
-    expect(history.location.search).toEqual('?showAll=1&subjects=Communication');
+    expect(history.location.search).toEqual('?subjects=Communication&showAll=1');
   });
 
   test('renders a typeahead dropdown', async () => {
-    const { container } = renderWithRouter(<SearchData><FacetListBase {...searchableDropdownProps} /></SearchData>);
+    const { container } = renderWithRouter((
+      <SearchData>
+        <FacetListBase {...searchableDropdownProps} />
+      </SearchData>
+    ));
 
     // assert the "no options" message does not show
     expect(screen.queryByText(NO_OPTIONS_FOUND)).not.toBeInTheDocument();

--- a/packages/catalog-search/src/tests/FacetListRefinement.test.jsx
+++ b/packages/catalog-search/src/tests/FacetListRefinement.test.jsx
@@ -15,7 +15,7 @@ const propsForNoRefinements = {
   title: FACET_ATTRIBUTES.SUBJECTS,
   currentRefinement: [],
   facetValueType: 'array',
-  refinementsFromQueryParams: {},
+  refinements: {},
   facetName: 'subjects',
   searchForItems: () => {},
 };
@@ -29,7 +29,7 @@ const propsForRefinements = {
     isRefined: false,
   }],
   facetValueType: 'array',
-  refinementsFromQueryParams: {},
+  refinements: {},
   searchForItems: () => {},
 };
 
@@ -48,7 +48,7 @@ const propsForActiveRefinements = {
   }],
   currentRefinement: [SUBJECTS.COMPUTER_SCIENCE],
   facetValueType: 'array',
-  refinementsFromQueryParams: { [FACET_ATTRIBUTES.SUBJECTS]: [SUBJECTS.COMPUTER_SCIENCE] },
+  refinements: { [FACET_ATTRIBUTES.SUBJECTS]: [SUBJECTS.COMPUTER_SCIENCE] },
 };
 
 describe('<FacetListRefinementBase />', () => {
@@ -124,7 +124,7 @@ describe('<FacetListRefinementBase />', () => {
       <SearchData>
         <FacetListRefinementBase
           {...propsForActiveRefinements}
-          refinementsFromQueryParams={{ ...propsForActiveRefinements.refinementsFromQueryParams, page: 3 }}
+          refinements={{ ...propsForActiveRefinements.refinements, page: 3 }}
         />
       </SearchData>,
       { route: '/search?page=3' },

--- a/packages/catalog-search/src/tests/SearchContext.test.jsx
+++ b/packages/catalog-search/src/tests/SearchContext.test.jsx
@@ -6,14 +6,14 @@ const activeFacetAttributes = ['subject', 'language'];
 describe('getRefinementsToSet', () => {
   it('converts query params that are arrays into arrays', () => {
     const queryParams = {
-      subject: 'science,math',
+      subject: ['science', 'math'],
       language: 'english',
     };
-    const refinements = {
+    const expectedRefinements = {
       subject: ['science', 'math'],
       language: ['english'],
     };
-    expect(getRefinementsToSet(queryParams, activeFacetAttributes)).toEqual(refinements);
+    expect(getRefinementsToSet(queryParams, activeFacetAttributes)).toEqual(expectedRefinements);
   });
   it('converts boolean query params to a number', () => {
     expect(getRefinementsToSet({ [SHOW_ALL_NAME]: '0' }, [])).toEqual({ [SHOW_ALL_NAME]: 0 });
@@ -24,7 +24,11 @@ describe('getRefinementsToSet', () => {
     expect(getRefinementsToSet(queryParams, activeFacetAttributes)).toEqual(expected);
   });
   it('does not modify non-active facets', () => {
-    const queryParams = { features: 'ENROLL_WITH_CODES, ANOTHER_FEATURE', anotherkey: '0', subject: 'bears,tigers' };
+    const queryParams = {
+      features: 'ENROLL_WITH_CODES, ANOTHER_FEATURE',
+      anotherkey: '0',
+      subject: ['bears', 'tigers'],
+    };
     const expected = { ...queryParams, subject: ['bears', 'tigers'] };
     expect(getRefinementsToSet(queryParams, activeFacetAttributes)).toEqual(expected);
   });


### PR DESCRIPTION
This PR refactors how the Algolia search refinements are synced with the URL query parameters, and fixes a bug where a refinement with a command in it would break the search results.

On initial page load, it parses the URL query parameters and applies them to the Algolia search refinements. However, previously, when a new refinement is selected, we would add it to the refinements reducer state and `SearchContext` would respond to this change, and attempt to update the query parameters.

This causes issues because the logic that parses the initial URL query parameters was also attempting to parse updates made to the query params when the refinements reducer changed. As a result, we were in a situation where these two bits of logic were conflicting and causing issues.

This PR updates this logic to only parse the query parameters to update the refinements reducer state on initial component mount, instead of any time the query parameter string changed. This removes the conflicting logic and maintains a "source-of-truth" for which search state should be synced with URL query parameters.

**Note: This is a breaking change!**

### Testing instructions

1. Checkout this branch of `frontend-enterprise` locally.
2. Checkout latest `frontend-app-learner-portal-enterprise`.
3. Add `@edx/frontend-enterprise-catalog-search` to the Learner Portal module.config.js file:
```js
{
  moduleName: '@edx/frontend-enterprise-catalog-search',
  dir: '../frontend-enterprise/packages/catalog-search',
  dist: 'src',
},
```
4. Add the production Algolia API keys in .env.private in Learner Portal and update `useDefaultSearchFilters` to return the following filter string: `enterprise_customer_uuids:8ea70d02-c210-4009-a86d-e23423dcda7d`. This will ensure the search results return with refinements that have commas (e.g., "University of Maryland, College Park").
5. Run `npm start` in Learner Portal. and browse to the search page (e.g., https://localhost:8734/test-enterprise/search).
6. Select the "University of Maryland, College Park" option under the "Partner" facet and observe the full refinement label is shown as a badge rather than being split on the comma.
7. Select another partner while leaving the previous one selected; observe the search results update accordingly and an additional query parameter is added to the URL as appropriate.