### PR TITLE
feat: ENT4816- Add jobs dropdown

### DIFF
--- a/packages/catalog-search/src/FacetListBase.jsx
+++ b/packages/catalog-search/src/FacetListBase.jsx
@@ -21,6 +21,8 @@ const FacetListBase = ({
   searchForItems,
   variant,
   noDisplay,
+  doRefinement,
+  customAttribute,
 }) => {
   const { refinements, dispatch } = useContext(SearchContext);
 
@@ -30,21 +32,24 @@ const FacetListBase = ({
    * longer any selected options for that particular facet attribute.
    */
   const handleInputOnChange = (item) => {
+    // if it is desired to load the same attribute data in multiple dropdowns then
+    // customAttribute can be passed to differentiate them.
+    const index = customAttribute || attribute;
     if (item.value && facetValueType === 'array') {
       if (item.value.length > 0) {
-        if (refinements[attribute]?.includes(item.label)) {
-          dispatch(removeFromRefinementArray(attribute, item.label));
+        if (refinements[index]?.includes(item.label)) {
+          dispatch(removeFromRefinementArray(index, item.label));
         } else {
-          dispatch(addToRefinementArray(attribute, item.label));
+          dispatch(addToRefinementArray(index, item.label));
         }
       } else {
-        dispatch(deleteRefinementAction(attribute));
+        dispatch(deleteRefinementAction(index));
       }
     } else if (facetValueType === 'bool') {
       // eslint-disable-next-line no-bitwise
-      dispatch(setRefinementAction(attribute, refinements[attribute] ^ 1));
+      dispatch(setRefinementAction(index, refinements[index] ^ 1));
     } else if (facetValueType === 'single-item') {
-      dispatch(setRefinementAction(attribute, [item.label]));
+      dispatch(setRefinementAction(index, [item.label]));
     }
   };
 
@@ -55,7 +60,13 @@ const FacetListBase = ({
       }
 
       return items.map((item) => {
-        const isChecked = isCheckedField ? item[isCheckedField] : !!item.value;
+        let isChecked;
+        if (doRefinement) {
+          isChecked = isCheckedField ? item[isCheckedField] : !!item.value;
+        } else {
+          const index = customAttribute || attribute;
+          isChecked = refinements[index]?.includes(item.label);
+        }
         return (
           <FacetItem
             key={item.label}
@@ -100,9 +111,11 @@ const FacetListBase = ({
 FacetListBase.defaultProps = {
   isCheckedField: null,
   typeaheadOptions: null,
+  customAttribute: null,
   searchForItems: null,
   variant: STYLE_VARIANTS.inverse,
   noDisplay: false,
+  doRefinement: true,
 };
 
 FacetListBase.propTypes = {
@@ -110,6 +123,7 @@ FacetListBase.propTypes = {
   facetValueType: PropTypes.oneOf(['array', 'bool', 'single-item']).isRequired,
   isBold: PropTypes.bool.isRequired,
   isCheckedField: PropTypes.string,
+  customAttribute: PropTypes.string,
   items: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   title: PropTypes.string.isRequired,
   typeaheadOptions: PropTypes.shape({
@@ -120,6 +134,7 @@ FacetListBase.propTypes = {
   searchForItems: PropTypes.func,
   variant: PropTypes.oneOf([STYLE_VARIANTS.default, STYLE_VARIANTS.inverse]),
   noDisplay: PropTypes.bool,
+  doRefinement: PropTypes.bool,
 };
 
 export default FacetListBase;

--- a/packages/catalog-search/src/SearchContext.jsx
+++ b/packages/catalog-search/src/SearchContext.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { useLocation, useHistory } from 'react-router-dom';
 import { useIsFirstRender } from '@edx/frontend-enterprise-utils';
 
-import { BOOLEAN_FILTERS, SEARCH_FACET_FILTERS } from './data/constants';
+import { BOOLEAN_FILTERS, SEARCH_FACET_FILTERS, ADDITIONAL_FACET_FILTERS } from './data/constants';
 import { refinementsReducer } from './data/reducer';
 import { setMultipleRefinementsAction } from './data/actions';
 import { searchParamsToObject, stringifyRefinements } from './data/utils';
@@ -15,7 +15,9 @@ export const SearchContext = createContext();
 export const getRefinementsToSet = (queryParams, activeFacetAttributes) => {
   const refinementsToSet = {};
   Object.entries(queryParams).forEach(([key, value]) => {
-    if (activeFacetAttributes.includes(key)) {
+    // Any additional facet filter to SEARCH_FACET_FILTERS who's data needs to be kept in an
+    // array can live in ADDITIONAL_FACET_FILTERS.
+    if (activeFacetAttributes.includes(key) || ADDITIONAL_FACET_FILTERS.includes(key)) {
       const valueAsArray = Array.isArray(value) ? value : [value];
       refinementsToSet[key] = valueAsArray;
     } else if (BOOLEAN_FILTERS.includes(key)) {

--- a/packages/catalog-search/src/data/constants.js
+++ b/packages/catalog-search/src/data/constants.js
@@ -51,6 +51,8 @@ export const SEARCH_FACET_FILTERS = [
   },
 ];
 
+export const ADDITIONAL_FACET_FILTERS = ['skills.name', 'name', 'current_job'];
+
 if (features.LANGUAGE_FACET) {
   SEARCH_FACET_FILTERS.push({
     attribute: 'language',


### PR DESCRIPTION
The objective of this PR is to add more options to current Algolia widgets.
Newly added functionality in this PR:
1-Dropdown state in context was saved against attribute which can now be changed and saved against `customAttrbiute,` so multiple dropdowns can be loaded against the same attribute.
2- If it is desired to not refine the data from Algolia on the basis of user selection but only mark the checkboxes and save his selections.
3- Previously `SEARCH_FACET_FILTERS` selections were only saved as an array. Any other attributes value is saved as a string. Now if it is needed to save any other attribute value in the array then its key can be added in `ADDITIONAL_FACET_FILTERS.

https://openedx.atlassian.net/browse/ENT-4843
https://openedx.atlassian.net/browse/ENT-4844

Extra Details:
**doRefinement**:
We currently have a use case where we do not want to refine the data on the basis of user selections from `facet` but to save the user selection and show these checkboxes marked in the dropdown.
For that, I have added `doRefinement` flag which will be True by default and will work as it was working previously. But if this flag is set to false then checkboxes state will not be marked from algolia's `isRefined` flag and checked from the local state.
**customAttribute**:
We want to load two dropdowns for jobs from the same attribute and keep their state different. Since the state is saved against the attribute name, so to change the attribute name an optional `customAttribute` can be passed.
