### PR TITLE
fix: Updated FacetListBase to save list of selected item

### DIFF
--- a/packages/catalog-search/src/FacetListBase.jsx
+++ b/packages/catalog-search/src/FacetListBase.jsx
@@ -45,7 +45,7 @@ const FacetListBase = ({
       // eslint-disable-next-line no-bitwise
       dispatch(setRefinementAction(attribute, refinementsFromQueryParams[attribute] ^ 1));
     } else if (facetValueType === 'single-item') {
-      dispatch(setRefinementAction(attribute, item.label));
+      dispatch(setRefinementAction(attribute, [item.label]));
     }
   };
 


### PR DESCRIPTION
Updated FacetListBase to save a list of the selected items even for `single-item` face-value-type.
At many places we assume that we will get a list of items, otherwise fails. to keep that consistent with the `array` type, setting the array with one value.