### PR TITLE
ci: release workflow should only increment versions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
     - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.
 
 **Post merge:**
-- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files and created Git tags for those versions.
+- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created Git tags for those versions.
 - [ ] Run the ``Publish from package.json`` Github Action workflow to publish these new package versions to NPM.
 - [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
     - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 
 **Post merge:**
 - [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created Git tags for those versions.
-- [ ] Run the ``Publish from package.json`` Github Action workflow to publish these new package versions to NPM.
+- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/edx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
+    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
 - [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
     - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+**Merge checklist:**
+- [ ] Ensure your commit message follows the semantic-release conventional commit message format
+- [ ] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
+    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.
+
+**Post merge:**
+- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files and created Git tags for those versions.
+- [ ] Run the ``Publish from package.json`` Github Action workflow to publish these new package versions to NPM.
+- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
+    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,7 @@ jobs:
         run: npm run test
       - name: Coverage Report
         uses: codecov/codecov-action@v1
-      - name: Publish Changed Packages
-        run: |
-          lerna version --yes
-          git fetch --all --tags
-          git show-ref --tags -d
-          lerna publish from-git --yes
+      - name: Increment Versions of Changed Packages
+        run: lerna version --yes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -99,9 +99,11 @@ where type must be one of ``[build, ci, docs, feat, fix, perf, refactor, revert,
 Versioning and releases
 *****
 
-This library has its version automatically updated by Lerna (i.e., ``lerna publish``) using semantic-versioning under-the-hood when the release is published to npm.
+This library has its version automatically updated by Lerna (i.e., ``lerna version``) using semantic-versioning under-the-hood when the release is published to npm. Lerna is configured to use independent versioning with conventional commits, as opposed to keeping all package versions in sync.
 
-Lerna is configured to use independent versioning with conventional commits, as opposed to keeping all package versions in sync.
+When a PR is merged, Lerna creates a release commit (e.g., ``chore(release): publish``). In this commit, Lerna increments the versions in the appropriate package.json files for any changed packages, creates Git tags, and updates the CHANGELOG file.
+
+To publish the packages that had their versions incremented, you must manually trigger the ``Publish from package.json`` Github Action workflow `found here <https://github.com/edx/frontend-enterprise/actions/workflows/publish-from-package.yml>`_. It will publish any versions denoted in the package.json files that are not currently published on the NPM registry, publishing the incremented versions from the aforementioned release commit.
 
 Preview changed packages in CI with Github Actions
 -----


### PR DESCRIPTION
**Merge checklist:**
- [x] Ensure your commit message follows the semantic-release conventional commit message format
- [x] Once CI is passing, verify the package versions that Lerna will increment to in the Github Action CI workflow logs.
    - *Note*: This may be found in the "Preview Updated Versions (dry run)" step in the Github Action CI workflow logs.

**Post merge:**
- [ ] Verify Lerna created a release commit (e.g., ``chore(release): publish``) that incremented versions in relevant package.json and CHANGELOG files, and created Git tags for those versions.
- [ ] Run the ``Publish from package.json`` Github Action [workflow](https://github.com/edx/frontend-enterprise/actions/workflows/publish-from-package.yml) to publish these new package versions to NPM.
    - This may be triggered by clicking the "Run workflow" option for the ``master`` branch.
- [ ] Verify the new package versions were published to NPM (i.e., ``npm view <package_name> versions --json``).
    - *Note*: There may be a slight delay between when the workflow finished and when NPM reports the package version as being published. If it doesn't appear right away in the above command, try again in a few minutes.
