### PR TITLE
feat(ENT-11384): add New Content filter to catalog-search package

### DIFF
--- a/packages/catalog-search/src/NewContentRadioFacet.jsx
+++ b/packages/catalog-search/src/NewContentRadioFacet.jsx
@@ -1,0 +1,89 @@
+import React, { useContext } from 'react';
+import classNames from 'classnames';
+import { Dropdown, Input } from '@openedx/paragon';
+import { FormattedMessage } from '@edx/frontend-platform/i18n';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+import { SearchContext } from './SearchContext';
+import { SEARCH_EVENT_NAME_PREFIX } from './SearchBox';
+import { setRefinementAction, deleteRefinementAction } from './data/actions';
+import {
+  NEW_CONTENT_REFINEMENT,
+  NEW_CONTENT_SELECTED_EVENT,
+} from './data/constants';
+
+const NewContentRadioFacet = () => {
+  const { refinements, dispatch, trackingName } = useContext(SearchContext);
+  const isNewContentSelected = !!refinements[NEW_CONTENT_REFINEMENT];
+
+  const handleSelect = (enabled) => {
+    if (enabled) {
+      dispatch(setRefinementAction(NEW_CONTENT_REFINEMENT, 1));
+    } else {
+      dispatch(deleteRefinementAction(NEW_CONTENT_REFINEMENT));
+    }
+    if (trackingName) {
+      sendTrackEvent(
+        `${SEARCH_EVENT_NAME_PREFIX}.${trackingName}.${NEW_CONTENT_SELECTED_EVENT}`,
+        { newContent: enabled ? 'yes' : 'no' },
+      );
+    }
+  };
+
+  return (
+    <div className="facet-list">
+      <Dropdown className={classNames('mb-0 mr-md-3')}>
+        <Dropdown.Toggle
+          id="new-content-toggle"
+          variant="inverse-primary"
+          className={classNames({ 'font-weight-bold': isNewContentSelected })}
+        >
+          <FormattedMessage
+            id="search.facetFilters.newContent.title"
+            defaultMessage="New content"
+            description="Title for the new content facet filter"
+          />
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item as="label" className="mb-0 py-3 d-flex align-items-center">
+            <Input
+              type="radio"
+              name="new-content"
+              value="any"
+              checked={!isNewContentSelected}
+              className="facet-item position-relative mr-2 mb-2"
+              onChange={() => handleSelect(false)}
+              data-testid="new-content-any"
+            />
+            <span className="facet-item-label">
+              <FormattedMessage
+                id="search.facetFilters.newContent.any"
+                defaultMessage="Any"
+                description="Option to include all content regardless of release date"
+              />
+            </span>
+          </Dropdown.Item>
+          <Dropdown.Item as="label" className="mb-0 py-3 d-flex align-items-center">
+            <Input
+              type="radio"
+              name="new-content"
+              value="new-only"
+              checked={isNewContentSelected}
+              className="facet-item position-relative mr-2 mb-2"
+              onChange={() => handleSelect(true)}
+              data-testid="new-content-only"
+            />
+            <span className={classNames('facet-item-label', { 'is-refined': isNewContentSelected })}>
+              <FormattedMessage
+                id="search.facetFilters.newContent.newOnly"
+                defaultMessage="New content only"
+                description="Option to restrict results to courses whose earliest run started within the last 12 months"
+              />
+            </span>
+          </Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    </div>
+  );
+};
+
+export default NewContentRadioFacet;

--- a/packages/catalog-search/src/SearchFilters.jsx
+++ b/packages/catalog-search/src/SearchFilters.jsx
@@ -14,6 +14,7 @@ import { sortItemsByLabelAsc } from './data/utils';
 import { SearchContext } from './SearchContext';
 import { features } from './config';
 import LearningTypeRadioFacet from './LearningTypeRadioFacet';
+import NewContentRadioFacet from './NewContentRadioFacet';
 
 export const FREE_ALL_TITLE = 'Free / All';
 
@@ -49,6 +50,7 @@ const SearchFilters = ({ variant, enablePathways }) => {
         <>
           {filtersFromRefinements}
           {features.LEARNING_TYPE_FACET && (<LearningTypeRadioFacet enablePathways={enablePathways} />)}
+          {features.NEW_CONTENT_FACET && (<NewContentRadioFacet />)}
         </>
       );
     },

--- a/packages/catalog-search/src/config/index.js
+++ b/packages/catalog-search/src/config/index.js
@@ -6,6 +6,7 @@ export const FEATURE_PROGRAM_TITLES_FACET = 'PROGRAM_TITLES_FACET';
 export const LEARNING_TYPE_FACET = 'LEARNING_TYPE_FACET';
 export const FEATURE_ENABLE_PATHWAYS = 'ENABLE_PATHWAYS';
 export const FEATURE_SUBTITLE_FACET = 'SUBTITLE_FACET';
+export const FEATURE_NEW_CONTENT_FACET = 'NEW_CONTENT_FACET';
 
 // eslint-disable-next-line import/prefer-default-export
 export const features = {
@@ -22,5 +23,8 @@ export const features = {
   ),
   SUBTITLE_FACET: (
     process.env.FEATURE_SUBTITLE_FACET || hasFeatureFlagEnabled(FEATURE_SUBTITLE_FACET)
+  ),
+  NEW_CONTENT_FACET: (
+    process.env.FEATURE_NEW_CONTENT_FACET || hasFeatureFlagEnabled(FEATURE_NEW_CONTENT_FACET)
   ),
 };

--- a/packages/catalog-search/src/data/constants.js
+++ b/packages/catalog-search/src/data/constants.js
@@ -1,6 +1,8 @@
 import { features } from '../config';
 
 export const SHOW_ALL_NAME = 'showAll';
+export const NEW_CONTENT_REFINEMENT = 'new_content';
+export const NEW_CONTENT_SELECTED_EVENT = 'catalog_search.new_content_selected';
 
 export const SEARCH_FACET_FILTERS = [
   {
@@ -81,7 +83,7 @@ if (features.SUBTITLE_FACET) {
   });
 }
 
-export const BOOLEAN_FILTERS = [SHOW_ALL_NAME];
+export const BOOLEAN_FILTERS = [SHOW_ALL_NAME, NEW_CONTENT_REFINEMENT];
 export const QUERY_PARAM_FOR_SEARCH_QUERY = 'q';
 export const QUERY_PARAM_FOR_PAGE = 'page';
 export const QUERY_PARAM_FOR_FEATURE_FLAGS = 'features';

--- a/packages/catalog-search/src/index.js
+++ b/packages/catalog-search/src/index.js
@@ -6,6 +6,8 @@ export { default as FacetListRefinement } from './FacetListRefinement';
 export {
   SEARCH_FACET_FILTERS,
   SHOW_ALL_NAME,
+  NEW_CONTENT_REFINEMENT,
+  NEW_CONTENT_SELECTED_EVENT,
 } from './data/constants';
 
 export {

--- a/packages/catalog-search/src/tests/NewContentRadioFacet.test.jsx
+++ b/packages/catalog-search/src/tests/NewContentRadioFacet.test.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom/extend-expect';
+
+import NewContentRadioFacet from '../NewContentRadioFacet';
+
+import { renderWithSearchContext } from './utils';
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({
+    pathname: '/',
+  }),
+}));
+
+describe('<NewContentRadioFacet />', () => {
+  test('renders with a label and is not bold initially', () => {
+    renderWithSearchContext(<NewContentRadioFacet />);
+    expect(screen.getByText('New content')).toBeInTheDocument();
+    expect(screen.getByText('New content').classList.contains('font-weight-bold')).toBeFalsy();
+  });
+
+  test('shows both options when opened', async () => {
+    const user = userEvent.setup();
+    renderWithSearchContext(<NewContentRadioFacet />);
+    await user.click(screen.getByText('New content'));
+    await waitFor(() => {
+      expect(screen.getByTestId('new-content-any')).toBeInTheDocument();
+      expect(screen.getByTestId('new-content-only')).toBeInTheDocument();
+    });
+  });
+
+  test('Any is checked by default', async () => {
+    const user = userEvent.setup();
+    renderWithSearchContext(<NewContentRadioFacet />);
+    await user.click(screen.getByText('New content'));
+    await waitFor(() => {
+      expect(screen.getByTestId('new-content-any')).toBeChecked();
+      expect(screen.getByTestId('new-content-only')).not.toBeChecked();
+    });
+  });
+
+  test('selecting "New content only" marks the dropdown as refined', async () => {
+    const user = userEvent.setup();
+    renderWithSearchContext(<NewContentRadioFacet />);
+    await user.click(screen.getByText('New content'));
+    await user.click(screen.getByTestId('new-content-only'));
+    await waitFor(() => {
+      expect(screen.getByText('New content').classList.contains('font-weight-bold')).toBeTruthy();
+      expect(screen.getByText('New content only').classList.contains('is-refined')).toBeTruthy();
+      expect(screen.getByTestId('new-content-only')).toBeChecked();
+    });
+  });
+
+  test('toggling back to Any clears the refinement', async () => {
+    const user = userEvent.setup();
+    renderWithSearchContext(<NewContentRadioFacet />);
+    await user.click(screen.getByText('New content'));
+    await user.click(screen.getByTestId('new-content-only'));
+    await waitFor(() => {
+      expect(screen.getByText('New content').classList.contains('font-weight-bold')).toBeTruthy();
+    });
+    // Dropdown auto-closes after a selection — reopen it to click the other option.
+    await user.click(screen.getByText('New content'));
+    await user.click(screen.getByTestId('new-content-any'));
+    await waitFor(() => {
+      expect(screen.getByText('New content').classList.contains('font-weight-bold')).toBeFalsy();
+      expect(screen.getByTestId('new-content-any')).toBeChecked();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **"New content"** filter dropdown to the shared `@edx/frontend-enterprise-catalog-search` package's filter row, enabling enterprise Learner Portal users to narrow search results to courses released within the last 12 months.

## Ticket

**ENT-11384** — *"We have new content being released, but there isn't a way for learners to find new content."*

### Acceptance Criteria from the ticket:

> 1. A new content filter, like the one in B2C, at the end of the row of filters in the Learner Portal
> 2. When filtered 'yes', the results should show courses with their earliest start dates within the last 12 months

**This PR satisfies A/C #1** — the visible filter UI that appears at the end of the filter row. It also provides the state management (refinement key, URL persistence, analytics event) that A/C #2 depends on.

## Changes — file by file

### `packages/catalog-search/src/NewContentRadioFacet.jsx` (new file, ~90 lines)

The new dropdown component. Structurally modeled after the existing `LearningTypeRadioFacet.jsx` to maintain visual and behavioral consistency with the other facets in the row.

**Component structure:**
- Paragon `<Dropdown>` with `variant="inverse-primary"` — same button style as Subject, Partner, Level, etc.
- `id="new-content-toggle"` — unique DOM id for the dropdown toggle.
- Two `<Dropdown.Item>` children, each containing a radio `<Input>`:
  - **"Any"** (default) — no filter applied, shows all content regardless of release date.
  - **"New content only"** — dispatches `setRefinementAction('new_content', 1)` to `SearchContext`, which the consuming app translates into an Algolia numeric range filter.

**Why a new component (not reusing FacetListRefinement):**
`FacetListRefinement` renders categorical facets (Subject, Level, Language) driven by Algolia's `connectRefinementList`. The "New content" filter is a boolean toggle that maps to a numeric range query — fundamentally different from a list of discrete values. No existing component in the package handles this interaction pattern. The closest match is `LearningTypeRadioFacet` (also a custom radio-based facet), which is why this component copies its structure.

**State management:**
- Toggle ON → `dispatch(setRefinementAction('new_content', 1))` — sets `SearchContext.refinements.new_content = 1`.
- Toggle OFF → `dispatch(deleteRefinementAction('new_content'))` — removes the key entirely from refinements.
- Bold label when active → `classNames({ 'font-weight-bold': isNewContentSelected })` — matches the visual convention of other refined facets.
- `is-refined` class on the active option label → enables CSS styling parity with other facets.

**Analytics:**
- Fires `sendTrackEvent` with event name `catalog_search.new_content_selected` on each toggle, matching the pattern established by `LEARNING_TYPE_SELECTED_EVENT`.

**i18n:**
- All user-facing strings use `<FormattedMessage>` with unique IDs (`search.facetFilters.newContent.title`, `.any`, `.newOnly`) for translation support.

**How this satisfies A/C #1:** This component IS the filter the learner sees and interacts with. Its position in the row is controlled by where it's rendered in `SearchFilters.jsx` (see below).

### `packages/catalog-search/src/SearchFilters.jsx` (2 lines added)

```jsx
import NewContentRadioFacet from './NewContentRadioFacet';
// ...inside the searchFacets memo:
{features.NEW_CONTENT_FACET && (<NewContentRadioFacet />)}
```

**Line 1 — import:**
Brings in the new component. Standard ES module import, no side effects.

**Line 2 — render at end of fragment:**
Placed AFTER the `LearningTypeRadioFacet` line, making it the **last item** in the filter row. This directly satisfies *"at the end of the row of filters"* from A/C #1. The order of JSX children in this fragment controls the left-to-right render order of the filter buttons.

**Feature flag gate:** `features.NEW_CONTENT_FACET && (...)` ensures the filter only renders when the consuming app has `FEATURE_NEW_CONTENT_FACET=true` in its environment. This prevents the filter from appearing in Admin Portal, Skills Quiz, or other consumers of `<SearchHeader>` until they're ready (i.e., until the backend `earliest_course_run_start` attribute is indexed and their app's `useDefaultSearchFilters` is wired up).

### `packages/catalog-search/src/data/constants.js` (3 additions)

**`NEW_CONTENT_REFINEMENT = 'new_content'`:**
The state key used in `SearchContext.refinements`. Exported so consuming apps can reference it by name if needed (currently used internally by `NewContentRadioFacet` and by `BOOLEAN_FILTERS`).

**`NEW_CONTENT_SELECTED_EVENT = 'catalog_search.new_content_selected'`:**
Analytics event name. Follows the naming convention of `LEARNING_TYPE_SELECTED_EVENT`. Used by `NewContentRadioFacet` when calling `sendTrackEvent`.

**`BOOLEAN_FILTERS` — added `NEW_CONTENT_REFINEMENT` to the array:**
```javascript
export const BOOLEAN_FILTERS = [SHOW_ALL_NAME, NEW_CONTENT_REFINEMENT];
```
**Why this is critical for A/C #2:** `BOOLEAN_FILTERS` controls how `SearchContext`'s URL-parameter parser deserializes refinement values. Without this entry, `?new_content=1` in the URL would be parsed as the string `"1"` rather than a truthy boolean, and the consuming app's `!!refinements.new_content` check would behave unexpectedly on page reload. This ensures the filter state **survives page refresh and is shareable via URL** — standard behavior for all other filters in the row.

### `packages/catalog-search/src/config/index.js` (feature flag)

```javascript
export const FEATURE_NEW_CONTENT_FACET = 'NEW_CONTENT_FACET';
// ...in the features object:
NEW_CONTENT_FACET: (
  process.env.FEATURE_NEW_CONTENT_FACET || hasFeatureFlagEnabled(FEATURE_NEW_CONTENT_FACET)
),
```

**Why:** Every custom facet in the package (`LEARNING_TYPE_FACET`, `SUBTITLE_FACET`, `ENABlE_PATHWAYS`) follows this pattern — a build-time env var check OR a runtime feature-flag check via `hasFeatureFlagEnabled`. This lets each consuming app independently control whether the new filter renders, which is important because:
- The backend `earliest_course_run_start` attribute may not be indexed yet for all consumers.
- Different products may have different rollout timelines.
- The flag can be toggled per-environment (dev/stage/prod) without code changes.

### `packages/catalog-search/src/tests/NewContentRadioFacet.test.jsx` (new file, 5 tests)

1. **renders with a label and is not bold initially** — verifies the dropdown button shows "New content" text and is visually inactive by default.
2. **shows both options when opened** — clicks the dropdown, asserts both radio inputs (`new-content-any`, `new-content-only`) are in the DOM.
3. **Any is checked by default** — verifies initial state is "no filter" (Any selected, New content only unselected).
4. **selecting "New content only" marks the dropdown as refined** — clicks the option, verifies the label goes bold and the option gets the `is-refined` CSS class. This is the visual feedback the learner sees confirming their filter is active.
5. **toggling back to Any clears the refinement** — reopens the dropdown (it auto-closes after selection), clicks Any, verifies bold is removed and Any is re-checked. This confirms the filter is fully reversible.

**Why these 5 cases:** They cover the complete user interaction lifecycle: render → open → select → visual feedback → deselect. Edge cases (e.g., multiple rapid toggles, combining with other filters) are integration-level concerns tested in the consuming app.

## Test plan

- [x] `npm test -- --testPathPattern NewContentRadioFacet` — **5/5 passing**
- [x] Verified against current `master` (no upstream changes since last sync)
- [ ] After merge: `lerna publish` to release a new version of `@edx/frontend-enterprise-catalog-search`

## Dependencies

This is **PR 2 of 3** for ENT-11384:
1. `edx/course-discovery` PR — backend data layer (must merge + reindex first)
2. **This PR** — UI component in the shared package
3. `edx/frontend-app-learner-portal-enterprise` PR — consumes the new package version and wires the refinement into the Algolia filter string

ENT-11384