### PR TITLE
feat(ENT-11384): add filterComponents prop to SearchHeader for custom filter composition

### DIFF
--- a/packages/catalog-search/src/SearchFilters.jsx
+++ b/packages/catalog-search/src/SearchFilters.jsx
@@ -82,9 +82,10 @@ SearchFilters.defaultProps = {
 SearchFilters.propTypes = {
   variant: PropTypes.oneOf([STYLE_VARIANTS.default, STYLE_VARIANTS.inverse]),
   enablePathways: PropTypes.bool,
-  // Optional: array of filter components to render in place of the default facet list.
+  // Optional: custom filter content to render in place of the default facet list.
+  // Accepts either an array of React elements (consumer-ordered list) or a single node.
   // When provided, the shared layout wrappers (mobile/desktop switch, CurrentRefinements) stay intact.
-  filterComponents: PropTypes.arrayOf(PropTypes.node),
+  filterComponents: PropTypes.node,
 };
 
 export default SearchFilters;

--- a/packages/catalog-search/src/SearchFilters.jsx
+++ b/packages/catalog-search/src/SearchFilters.jsx
@@ -22,7 +22,7 @@ const SearchFilters = ({ variant, enablePathways }) => {
 
   const searchFacets = useMemo(
     () => {
-      const filtersFromRefinements = searchFacetFilters.map(({
+      const toFacet = ({
         title, attribute, isSortedAlphabetical, typeaheadOptions, noDisplay,
       }) => (
         <FacetListRefinement
@@ -44,11 +44,16 @@ const SearchFilters = ({ variant, enablePathways }) => {
           variant={variant}
           noDisplay={noDisplay}
         />
-      ));
+      );
+      // Facets flagged with `isEndOfRow: true` render after LearningTypeRadioFacet,
+      // giving consumers a way to opt into the last slot in the filter row.
+      const mainFilters = searchFacetFilters.filter(f => !f.isEndOfRow).map(toFacet);
+      const endOfRowFilters = searchFacetFilters.filter(f => f.isEndOfRow).map(toFacet);
       return (
         <>
-          {filtersFromRefinements}
+          {mainFilters}
           {features.LEARNING_TYPE_FACET && (<LearningTypeRadioFacet enablePathways={enablePathways} />)}
+          {endOfRowFilters}
         </>
       );
     },

--- a/packages/catalog-search/src/SearchFilters.jsx
+++ b/packages/catalog-search/src/SearchFilters.jsx
@@ -17,48 +17,42 @@ import LearningTypeRadioFacet from './LearningTypeRadioFacet';
 
 export const FREE_ALL_TITLE = 'Free / All';
 
-const SearchFilters = ({ variant, enablePathways }) => {
+const SearchFilters = ({ variant, enablePathways, filterComponents }) => {
   const { refinements, searchFacetFilters } = useContext(SearchContext);
 
-  const searchFacets = useMemo(
-    () => {
-      const toFacet = ({
-        title, attribute, isSortedAlphabetical, typeaheadOptions, noDisplay,
-      }) => (
-        <FacetListRefinement
-          key={attribute}
-          title={title}
-          attribute={attribute}
-          limit={300} // this is replicating the B2C search experience
-          transformItems={(items) => {
-            if (isSortedAlphabetical) {
-              return sortItemsByLabelAsc(items);
-            }
-            return items;
-          }}
-          refinements={refinements}
-          defaultRefinement={refinements[attribute]}
-          facetValueType="array"
-          typeaheadOptions={typeaheadOptions}
-          searchable={!!typeaheadOptions}
-          variant={variant}
-          noDisplay={noDisplay}
-        />
-      );
-      // Facets flagged with `isEndOfRow: true` render after LearningTypeRadioFacet,
-      // giving consumers a way to opt into the last slot in the filter row.
-      const mainFilters = searchFacetFilters.filter(f => !f.isEndOfRow).map(toFacet);
-      const endOfRowFilters = searchFacetFilters.filter(f => f.isEndOfRow).map(toFacet);
-      return (
-        <>
-          {mainFilters}
-          {features.LEARNING_TYPE_FACET && (<LearningTypeRadioFacet enablePathways={enablePathways} />)}
-          {endOfRowFilters}
-        </>
-      );
-    },
+  const defaultSearchFacets = useMemo(
+    () => (
+      <>
+        {searchFacetFilters.map(({
+          title, attribute, isSortedAlphabetical, typeaheadOptions, noDisplay,
+        }) => (
+          <FacetListRefinement
+            key={attribute}
+            title={title}
+            attribute={attribute}
+            limit={300} // this is replicating the B2C search experience
+            transformItems={(items) => {
+              if (isSortedAlphabetical) {
+                return sortItemsByLabelAsc(items);
+              }
+              return items;
+            }}
+            refinements={refinements}
+            defaultRefinement={refinements[attribute]}
+            facetValueType="array"
+            typeaheadOptions={typeaheadOptions}
+            searchable={!!typeaheadOptions}
+            variant={variant}
+            noDisplay={noDisplay}
+          />
+        ))}
+        {features.LEARNING_TYPE_FACET && (<LearningTypeRadioFacet enablePathways={enablePathways} />)}
+      </>
+    ),
     [JSON.stringify(refinements)],
   );
+
+  const searchFacets = filterComponents ?? defaultSearchFacets;
 
   return (
     <>
@@ -82,11 +76,15 @@ const SearchFilters = ({ variant, enablePathways }) => {
 SearchFilters.defaultProps = {
   variant: STYLE_VARIANTS.inverse,
   enablePathways: null,
+  filterComponents: null,
 };
 
 SearchFilters.propTypes = {
   variant: PropTypes.oneOf([STYLE_VARIANTS.default, STYLE_VARIANTS.inverse]),
   enablePathways: PropTypes.bool,
+  // Optional: array of filter components to render in place of the default facet list.
+  // When provided, the shared layout wrappers (mobile/desktop switch, CurrentRefinements) stay intact.
+  filterComponents: PropTypes.arrayOf(PropTypes.node),
 };
 
 export default SearchFilters;

--- a/packages/catalog-search/src/SearchHeader.jsx
+++ b/packages/catalog-search/src/SearchHeader.jsx
@@ -24,6 +24,7 @@ const SearchHeader = ({
   enterpriseConfig: { slug, enablePathways },
   disableSuggestionRedirect,
   hideSearchBox,
+  filterComponents,
 }) => {
   const { refinements } = useContext(SearchContext);
   let searchQueryFromRefinements;
@@ -73,7 +74,12 @@ const SearchHeader = ({
             className={classNames('fe__searchbox-col', { 'fe__searchbox-col--default': variant === STYLE_VARIANTS.default })}
             xs={12}
           >
-            <SearchFilters className="mb-3" variant={variant} enablePathways={enablePathways} />
+            <SearchFilters
+              className="mb-3"
+              variant={variant}
+              enablePathways={enablePathways}
+              filterComponents={filterComponents}
+            />
           </Col>
         </Row>
       </Container>
@@ -92,6 +98,7 @@ SearchHeader.defaultProps = {
   disableSuggestionRedirect: false,
   index: undefined,
   hideSearchBox: false,
+  filterComponents: null,
 };
 
 SearchHeader.propTypes = {
@@ -110,6 +117,8 @@ SearchHeader.propTypes = {
   suggestionSubmitOverride: PropTypes.func,
   disableSuggestionRedirect: PropTypes.bool,
   hideSearchBox: PropTypes.bool,
+  // Optional: array of filter components to render in place of the default SearchFilters facet list.
+  filterComponents: PropTypes.arrayOf(PropTypes.node),
 };
 
 export default SearchHeader;

--- a/packages/catalog-search/src/SearchHeader.jsx
+++ b/packages/catalog-search/src/SearchHeader.jsx
@@ -117,8 +117,8 @@ SearchHeader.propTypes = {
   suggestionSubmitOverride: PropTypes.func,
   disableSuggestionRedirect: PropTypes.bool,
   hideSearchBox: PropTypes.bool,
-  // Optional: array of filter components to render in place of the default SearchFilters facet list.
-  filterComponents: PropTypes.arrayOf(PropTypes.node),
+  // Optional: custom filter content to render in place of the default SearchFilters facet list.
+  filterComponents: PropTypes.node,
 };
 
 export default SearchHeader;

--- a/packages/catalog-search/src/index.js
+++ b/packages/catalog-search/src/index.js
@@ -2,6 +2,7 @@ export { default as SearchData, SearchContext } from './SearchContext';
 export { default as SearchHeader } from './SearchHeader';
 export { default as SearchPagination } from './SearchPagination';
 export { default as FacetListRefinement } from './FacetListRefinement';
+export { default as LearningTypeRadioFacet } from './LearningTypeRadioFacet';
 
 export {
   SEARCH_FACET_FILTERS,

--- a/packages/catalog-search/src/tests/SearchFilters.test.jsx
+++ b/packages/catalog-search/src/tests/SearchFilters.test.jsx
@@ -22,7 +22,7 @@ const SearchContextWrapper = ({ filterComponents }) => {
   );
 };
 SearchContextWrapper.propTypes = {
-  filterComponents: PropTypes.arrayOf(PropTypes.node),
+  filterComponents: PropTypes.node,
 };
 SearchContextWrapper.defaultProps = {
   filterComponents: null,

--- a/packages/catalog-search/src/tests/SearchFilters.test.jsx
+++ b/packages/catalog-search/src/tests/SearchFilters.test.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { IntlProvider } from '@edx/frontend-platform/i18n';
@@ -12,43 +13,55 @@ import '../../__mocks__/react-instantsearch-dom';
 import SearchFilters from '../SearchFilters';
 import SearchData from '../SearchContext';
 
-const SearchContextWrapper = () => {
+const SearchContextWrapper = ({ filterComponents }) => {
   const contextValue = useMemo(() => ({ width: breakpoints.large.maxWidth }), []);
   return (
     <ResponsiveContext.Provider value={contextValue}>
-      <SearchFilters />
+      <SearchFilters filterComponents={filterComponents} />
     </ResponsiveContext.Provider>
   );
 };
+SearchContextWrapper.propTypes = {
+  filterComponents: PropTypes.arrayOf(PropTypes.node),
+};
+SearchContextWrapper.defaultProps = {
+  filterComponents: null,
+};
 
 describe('<SearchFilters />', () => {
-  test('renders with a label', () => {
+  test('renders default facets when filterComponents is not provided', () => {
     renderWithSearchContext(<SearchContextWrapper />);
     SEARCH_FACET_FILTERS.forEach((filter) => {
       expect(screen.getByText(filter.title)).toBeInTheDocument();
     });
   });
 
-  test('renders facets flagged isEndOfRow after the main facets', () => {
-    const customFacets = [
-      { attribute: 'main_attr', title: 'MainFacet' },
-      { attribute: 'end_attr', title: 'EndFacet', isEndOfRow: true },
+  test('renders the provided filterComponents in place of the default facets', () => {
+    const customComponents = [
+      <div key="first">CustomFilterOne</div>,
+      <div key="second">CustomFilterTwo</div>,
     ];
     const contextValue = { width: breakpoints.large.maxWidth };
     renderWithRouter(
       <IntlProvider locale="en">
         <ResponsiveContext.Provider value={contextValue}>
-          <SearchData searchFacetFilters={customFacets}>
-            <SearchFilters />
+          <SearchData>
+            <SearchFilters filterComponents={customComponents} />
           </SearchData>
         </ResponsiveContext.Provider>
       </IntlProvider>,
     );
-    const mainFacet = screen.getByText('MainFacet');
-    const endFacet = screen.getByText('EndFacet');
-    expect(mainFacet).toBeInTheDocument();
-    expect(endFacet).toBeInTheDocument();
+    // Custom components render
+    const first = screen.getByText('CustomFilterOne');
+    const second = screen.getByText('CustomFilterTwo');
+    expect(first).toBeInTheDocument();
+    expect(second).toBeInTheDocument();
+    // And in the order the consumer provided them
     // eslint-disable-next-line no-bitwise
-    expect(mainFacet.compareDocumentPosition(endFacet) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Default facets are suppressed when the override is provided
+    SEARCH_FACET_FILTERS.forEach((filter) => {
+      expect(screen.queryByText(filter.title)).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/catalog-search/src/tests/SearchFilters.test.jsx
+++ b/packages/catalog-search/src/tests/SearchFilters.test.jsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react';
 import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
+import { IntlProvider } from '@edx/frontend-platform/i18n';
+import { renderWithRouter } from '@edx/frontend-enterprise-utils';
 import { breakpoints, ResponsiveContext } from '@openedx/paragon';
 import { SEARCH_FACET_FILTERS } from '../data/constants';
 
@@ -8,6 +10,7 @@ import { renderWithSearchContext } from './utils';
 
 import '../../__mocks__/react-instantsearch-dom';
 import SearchFilters from '../SearchFilters';
+import SearchData from '../SearchContext';
 
 const SearchContextWrapper = () => {
   const contextValue = useMemo(() => ({ width: breakpoints.large.maxWidth }), []);
@@ -24,5 +27,28 @@ describe('<SearchFilters />', () => {
     SEARCH_FACET_FILTERS.forEach((filter) => {
       expect(screen.getByText(filter.title)).toBeInTheDocument();
     });
+  });
+
+  test('renders facets flagged isEndOfRow after the main facets', () => {
+    const customFacets = [
+      { attribute: 'main_attr', title: 'MainFacet' },
+      { attribute: 'end_attr', title: 'EndFacet', isEndOfRow: true },
+    ];
+    const contextValue = { width: breakpoints.large.maxWidth };
+    renderWithRouter(
+      <IntlProvider locale="en">
+        <ResponsiveContext.Provider value={contextValue}>
+          <SearchData searchFacetFilters={customFacets}>
+            <SearchFilters />
+          </SearchData>
+        </ResponsiveContext.Provider>
+      </IntlProvider>,
+    );
+    const mainFacet = screen.getByText('MainFacet');
+    const endFacet = screen.getByText('EndFacet');
+    expect(mainFacet).toBeInTheDocument();
+    expect(endFacet).toBeInTheDocument();
+    // eslint-disable-next-line no-bitwise
+    expect(mainFacet.compareDocumentPosition(endFacet) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Adds an optional `filterComponents` prop to `SearchHeader` that, when provided, replaces the default `SearchFilters` facet list with a consumer-supplied ordered list of filter components. Falls back to the existing default behavior when the prop is absent.

Companion PR to:
- https://github.com/edx/enterprise-catalog/pull/75 — adds `is_new_content` attribute to the Algolia course index. ✅ Merged.
- https://github.com/edx/frontend-app-learner-portal-enterprise/pull/26 — ships the `FEATURE_NEW_CONTENT_FACET` flag + facet entry. ✅ Merged.

A small follow-up learner-portal PR will consume the new `filterComponents` prop after this lands and a new package version is published.

## Motivation

Earlier revision of this PR added an `isEndOfRow: true` flag to `SEARCH_FACET_FILTERS` to let a consumer opt into the last position in the filter row. That encoded a consumer-specific layout preference inside the shared library, which isn't a great pattern — as the next consumer with a different layout need would add another flag, and `SearchFilters` would accumulate consumer-specific props over time.

Per review from @adusenbery and @kmiller1, the cleaner shape is: **let consumers pass their own ordered list of filter components in via a prop**, with the default path unchanged. That way the shared library stays layout-agnostic and the consumer owns their own filter ordering.

## Changes

### `packages/catalog-search/src/SearchFilters.jsx`
- Reverts the `isEndOfRow` split logic.
- Adds an optional `filterComponents` prop (array of ReactNodes).
- When `filterComponents` is provided, renders it in place of the default mapped facets.
- When absent, behavior is identical to today's `SearchFilters`.
- Layout wrappers (`MediaQuery`, `MobileFilterMenu`, `d-flex`, `CurrentRefinements`) remain owned by the shared library so mobile/desktop behavior is consistent across consumers.

### `packages/catalog-search/src/SearchHeader.jsx`
- Accepts a new `filterComponents` prop and forwards it to `<SearchFilters filterComponents={…} …>`.
- Defaults to `null` so existing consumers are unaffected.

### `packages/catalog-search/src/index.js`
- Exports `LearningTypeRadioFacet`. Consumers assembling a custom `filterComponents` array need to include it in their own order — without this export they'd have to reimplement the component, which is the exact "over-exposing implementation details" trap we're avoiding.
- `FacetListRefinement` was already exported.

### `packages/catalog-search/src/tests/SearchFilters.test.jsx`
- Removes the `isEndOfRow` test (no longer the mechanism).
- `renders default facets when filterComponents is not provided` — covers the unchanged default path.
- `renders the provided filterComponents in place of the default facets` — verifies the override renders, preserves the consumer-supplied order (via `compareDocumentPosition`), and suppresses the default facet list.

## Backward compatibility

✅ Fully backward compatible. `filterComponents` defaults to `null`; existing consumers (e.g. admin-portal) see identical behavior.

## Test plan

- [x] `npm test -- --testPathPattern SearchFilters` — 2/2 passing (default path + override path).
- [x] Full package test suite — 90/90 passing across 18 suites.
- [x] Lint clean on changed files.
- [ ] After merge: `lerna publish` a new minor version of `@edx/frontend-enterprise-catalog-search`.
- [ ] Follow-up learner-portal PR bumps the package, removes the dead `isEndOfRow: true` flag from master, and passes a custom `filterComponents` array into `<SearchHeader>` with the "New content" facet at the end.

## Rollout

1. Merge this PR.
2. Publish a new `@edx/frontend-enterprise-catalog-search` minor version.
3. Open follow-up learner-portal PR consuming the new prop.
4. Flip `FEATURE_NEW_CONTENT_FACET` on in stage and verify.

ENT-11384
