### PR TITLE
fix: release.yml bug which clobbered the output PR with codecov artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
         run: npm run build
       - name: Coverage Report
         uses: codecov/codecov-action@v5
+      - name: Clean up untracked files
+        run: git clean -fd
       - name: Update automation/lerna/version branch
         run: |
           git switch -C automation/lerna/version
@@ -52,23 +54,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate Lerna Versions PR
-        id: vpr
-        uses: peter-evans/create-pull-request@v4
-        with:
-            token: ${{ secrets.GITHUB_TOKEN }}
-            title: "chore(release): publish :tada:"
-            body: |
-              chore(release): publish :tada:
-            branch: automation/lerna/version
-            base: master
+        run: |
+          gh pr create \
+            --title "chore(release): publish :tada:" \
+            --body "chore(release): publish :tada:" \
+            --head automation/lerna/version \
+            --base master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable Lerna Versions PR Pull Request Automerge
-        if: steps.vpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pull-request-number: ${{ steps.vpr.outputs.pull-request-number }}
+        run: |
           # Must be "merge" (not "squash" or "rebase") so that lerna's
           # version-bump commit is preserved on master with its original SHA.
           # The git tags and GitHub Releases created by lerna point to that
           # commit; squash or rebase would orphan it.
-          merge-method: merge
+          gh pr merge automation/lerna/version --auto --merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ Preview changed packages in CI with Github Actions
 
 As a convenience, a dry run of the ``lerna version`` command is run for each push to determine which packages in the monorepo will be published should a PR get merged.
 
-.. |Build Status| image:: https://github.com/openedx/frontend-enterprise/actions/workflows/release.yml/badge.svg
-   :target: https://github.com/openedx/frontend-enterprise/actions
+.. |Build Status| image:: https://github.com/edx/frontend-enterprise/actions/workflows/release.yml/badge.svg
+   :target: https://github.com/edx/frontend-enterprise/actions
 .. |Codecov| image:: https://codecov.io/gh/edx/frontend-enterprise/branch/master/graph/badge.svg?token=lBHoe5P4Q3
    :target: https://codecov.io/gh/edx/frontend-enterprise

--- a/docs/how_tos/resolving_publishing_issues_with_lerna.rst
+++ b/docs/how_tos/resolving_publishing_issues_with_lerna.rst
@@ -5,7 +5,7 @@ In setting up the Lerna monorepo, there was a moment when the ``lerna publish`` 
 
 The result of this publishing failure was that the Git repository was in a state as if the release had been published, without the same, matching version existing on the NPM registry. This document serves as a starting point to resolve that situation.
 
-In the scenario where Git tags and a "chore: publish" commit were created for a new release without that release actually being published to NPM, you may `temporarily modify the release.yml Github Action workflow file <https://github.com/openedx/frontend-enterprise/blob/master/.github/workflows/release.yml#L40>`_ to run the following command instead of the default ``lerna publish``:
+In the scenario where Git tags and a "chore: publish" commit were created for a new release without that release actually being published to NPM, you may `temporarily modify the release.yml Github Action workflow file <https://github.com/edx/frontend-enterprise/blob/master/.github/workflows/release.yml#L40>`_ to run the following command instead of the default ``lerna publish``:
 
 ::
 


### PR DESCRIPTION
peter-evans/create-pull-request force-pushed over lerna's commits. Replace it with gh pr create since lerna already commits and pushes. Add git clean -fd to remove untracked files left by codecov-action.

This affected a recent release attempt which required manual intervention: https://github.com/edx/frontend-enterprise/pull/8#issuecomment-4324524928

Also, this is a followup from https://github.com/edx/frontend-enterprise/pull/10, there were just a few more docs updates I forgot to commit.