### PR TITLE
fix: inaccurate publish-from-package workflow job name.

### DIFF
--- a/.github/workflows/publish-from-package.yml
+++ b/.github/workflows/publish-from-package.yml
@@ -3,8 +3,8 @@ name: Publish from package.json
 on: [workflow_dispatch]
 
 jobs:
-  release:
-    name: Release
+  publish:
+    name: Publish to NPM
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
"Release" is the current job name for the publish workflow, but it's also the job name for the "Release" workflow.  That's confusing!

Fixed by renaming the publish workflow job name to actually have "publish" in the name.
