### PR TITLE
feat(ENT-11384): add 'Yes' label for is_new_content boolean facet

### DIFF
--- a/packages/catalog-search/src/messages.js
+++ b/packages/catalog-search/src/messages.js
@@ -198,6 +198,11 @@ const messages = defineMessages({
     defaultMessage: 'Tibetan',
     description: 'Option label for the tibetan language filter.',
   },
+  true: {
+    id: 'search.facetFilters.newContent.yes',
+    defaultMessage: 'Yes',
+    description: 'Option label for the new content boolean filter.',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
## Summary
Adds one entry to the i18n `messages` dictionary in `catalog-search`:

```js
'true': {
  id: 'search.facetFilters.newContent.yes',
  defaultMessage: 'Yes',
  description: 'Option label for the new content boolean filter.',
},
```

This maps the raw Algolia facet value `'true'` (returned for the `is_new_content` boolean attribute) to the user-visible label **'Yes'**, following the exact same pattern already used in this file for other facet values (`'Available Now'`, `'Introductory'`, etc.).

## Why
The new content filter dropdown on stage currently renders the option as the literal string `'true'` because there is no entry for that key in `messages.js`. `FacetItem.jsx:24` does `messages[item.label] ?? item.label` — without a mapping, it falls through to the raw Algolia value.

Tammi flagged this on the ticket as not matching the original design (see screenshot `image-20260225-180811.png` on ENT-11092), which shows the dropdown option as **"Yes"**.

## Behavior — unchanged
The display is decoupled from the value:
- The dispatched refinement value stays `'true'` (`FacetListBase.jsx` reads `item.label` for that)
- Algolia still receives `is_new_content:"true"` — the same query as today
- Only the rendered dropdown text changes from `"true"` → `"Yes"`

## Commits
1. `feat(ENT-11384): add 'Yes' label for is_new_content boolean facet` — adds the message
2. `style(ENT-11384): quote 'true' object key for consistency` — addresses inline review comment, matches surrounding code style (no behavior change)

## Test plan
- [x] Built `dist/` locally (`make build`), linked into `frontend-app-learner-portal-enterprise`
- [x] Verified `messages['true']` resolves to `'Yes'` at runtime via FacetItem
- [x] Confirmed `item.label` dispatched to the refinement reducer is still `'true'` — Algolia query untouched
- [ ] Visual verification on stage (after companion learner portal PR bumps the dep)

## Follow-up
Companion PR in `frontend-app-learner-portal-enterprise` will:
1. Rename filter title from 'New content' → 'Recently added' (also from the same design screenshot)
2. Bump `@2uinc/frontend-enterprise-catalog-search` to consume this change

## Tickets
- ENT-11092: https://2u-internal.atlassian.net/browse/ENT-11092
- ENT-11384: https://2u-internal.atlassian.net/browse/ENT-11384