### PR TITLE
chore: upgrade codecov-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
         git switch -c "actual-branch-not-detached-head"
         npx lerna version --allow-branch actual-branch-not-detached-head --no-git-tag-version --no-changelog --no-push --yes
     - name: Coverage Report
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7

--- a/.github/workflows/publish-from-package.yml
+++ b/.github/workflows/publish-from-package.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Coverage Report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
       - name: Publish to NPM from package.json versions
         run: npx lerna publish from-package --yes
         env:


### PR DESCRIPTION
**Description:**
Upgrade `codecov/codecov-action` from `v5` to `v7` in `.github/workflows/publish-from-package.yml` as specified in the ticket.

**Jira:**
[ENT-11952](https://2u-internal.atlassian.net/browse/ENT-11952)

**Changes**
- update `.github/workflows/publish-from-package.yml`
- change `codecov/codecov-action@v5` to `codecov/codecov-action@v7`