### PR TITLE
fix: rename new content facet option label to 'Recently added' (ENT-11384)

### DIFF
--- a/packages/catalog-search/src/messages.js
+++ b/packages/catalog-search/src/messages.js
@@ -200,7 +200,7 @@ const messages = defineMessages({
   },
   true: {
     id: 'search.facetFilters.newContent.yes',
-    defaultMessage: 'Yes',
+    defaultMessage: 'Recently added',
     description: 'Option label for the new content boolean filter.',
   },
 });


### PR DESCRIPTION
## What
Renames the `is_new_content` boolean facet's option label from **"Yes"** to **"Recently added"**, to match the B2C "new content" filter design.

## Why
In the Learner Portal the new-content facet currently shows an option labelled "Yes". The agreed design (matching B2C) is "Recently added".

## Change
`packages/catalog-search/src/messages.js` — `true` facet value `defaultMessage` `'Yes'` → `'Recently added'`.

